### PR TITLE
Add Basic Authentication Provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "aide",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "cached",
  "chrono",
  "figment",
@@ -1904,9 +1905,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
@@ -2056,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -28,6 +28,15 @@ dependencies = [
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -54,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -94,10 +103,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -180,17 +195,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -267,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
@@ -294,7 +309,7 @@ dependencies = [
  "cached_proc_macro",
  "cached_proc_macro_types",
  "futures",
- "hashbrown",
+ "hashbrown 0.14.5",
  "instant",
  "once_cell",
  "thiserror",
@@ -321,9 +336,12 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -711,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -724,21 +742,21 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -749,13 +767,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "headers"
@@ -832,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -855,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -932,7 +956,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -990,12 +1014,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -1020,7 +1044,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.6",
+ "socket2 0.5.8",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1034,16 +1058,17 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1104,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linked-hash-map"
@@ -1122,9 +1147,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1132,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru-cache"
@@ -1150,6 +1175,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matches"
@@ -1175,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1193,11 +1227,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -1304,6 +1338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,18 +1394,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
@@ -1408,10 +1452,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
+name = "overload"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1419,15 +1469,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1477,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1522,9 +1572,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1578,12 +1628,56 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -1679,14 +1773,17 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower 0.4.13",
+ "tracing",
+ "tracing-log 0.1.4",
+ "tracing-subscriber",
  "uuid",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -2074,10 +2171,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
+name = "sharded-slab"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -2121,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2255,6 +2367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,7 +2436,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.6",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2373,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2383,7 +2505,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2431,9 +2552,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2443,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2454,11 +2575,65 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2546,9 +2721,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-normalization"
@@ -2593,6 +2768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,9 +2781,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2621,23 +2802,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -2658,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2668,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2681,9 +2863,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2928,18 +3113,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ chrono = "~0.4.39"
 figment = { version = "~0.10.19", features = ["yaml"] }
 futures = "~0.3.31"
 http = "~1.1.0"
-hyper = "~1.4.0"
+hyper = "~1.4.1"
 inline_colorization = "~0.1.6"
 jsonwebtoken = "~9.3.0"
 ldap3 = "~0.11.5"
@@ -28,3 +28,9 @@ serde_json = "~1.0.137"
 tokio = { version = "~1.36.0", features = ["full"] }
 tower = "~0.4.13"
 uuid = { version = "~1.8.0", features = ["v4"] }
+# Core tracing
+tracing = "~0.1"
+# Subscriber implementations & formatting layers
+tracing-subscriber = { version = "~0.3", features = ["env-filter","json"] }
+# Bridge older `log` calls into `tracing`
+tracing-log = "~0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "~0.12.12", features = ["json"] }
 schemars = "~0.8.21"
 semver = { version = "~1.0.25", features = ["serde"] }
 serde = { version = "~1.0.217", features = ["derive"] }
-serde_json = "~1.0.137"
+serde_json = "~1.0.138"
 tokio = { version = "~1.36.0", features = ["full"] }
 tower = "~0.4.13"
 uuid = { version = "~1.8.0", features = ["v4"] }
@@ -34,3 +34,4 @@ tracing = "~0.1"
 tracing-subscriber = { version = "~0.3", features = ["env-filter","json"] }
 # Bridge older `log` calls into `tracing`
 tracing-log = "~0.1"
+base64 = "~0.22.1"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,23 +1,24 @@
+use std::sync::Arc;
+
+use futures::future;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use crate::models::User;
+use crate::store::Store;
+
 pub mod ecmwfapi_provider;
 pub mod jwt_provider;
 pub mod ldap_augmenter;
 pub mod openid_offline_provider;
 
-use std::sync::Arc;
+use ecmwfapi_provider::{EcmwfApiProvider, EcmwfApiProviderConfig};
+use jwt_provider::{JWTAuthConfig, JWTProvider};
+use ldap_augmenter::LDAPAugmenterConfig;
+use openid_offline_provider::{OpenIDOfflineProvider, OpenIDOfflineProviderConfig};
 
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use tracing::{debug, info, warn};
-
-use self::ecmwfapi_provider::{EcmwfApiProvider, EcmwfApiProviderConfig};
-use self::jwt_provider::{JWTAuthConfig, JWTProvider};
-use self::openid_offline_provider::{OpenIDOfflineProvider, OpenIDOfflineProviderConfig};
-use crate::models::User;
-use crate::store::Store;
-
-use self::ldap_augmenter::LDAPAugmenterConfig;
-
-/// A config enum to select which provider we use (ECMWF API, JWT, or OpenID Offline).
+/// A config enum to select which provider we use (ECMWF API, JWT, OpenID Offline).
 #[derive(Deserialize, Serialize, JsonSchema, Debug)]
 #[serde(tag = "type")]
 pub enum ProviderConfig {
@@ -39,61 +40,43 @@ pub enum AugmenterConfig {
     LDAPAugmenterConfig(LDAPAugmenterConfig),
 }
 
-/// A Provider is responsible for authenticating user credentials (e.g., a token).
+/// Trait describing a basic authentication provider (Bearer, Basic, etc.).
 #[async_trait::async_trait]
 pub trait Provider: Send + Sync {
-    /// A descriptive name for the provider (for logs/debug).
     fn get_name(&self) -> &str;
-
-    /// The "type" (e.g., "Bearer", "Basic") to match against in the Authorization header.
     fn get_type(&self) -> &str;
-
-    /// Given some credentials (e.g., a token), tries to produce a `User`.
     async fn authenticate(&self, credentials: &str) -> Result<User, String>;
 }
 
-/// An Augmenter can modify/enrich a `User` record after basic auth is done.
+/// Trait describing an augmenter that can enrich an authenticated user.
 #[async_trait::async_trait]
 pub trait Augmenter: Send + Sync {
     fn get_name(&self) -> &str;
     #[allow(unused)]
     fn get_type(&self) -> &str;
     fn get_realm(&self) -> &str;
-
-    /// Modifies the given `User` (e.g., fetch extra roles from LDAP).
     async fn augment(&self, user: &mut User) -> Result<(), String>;
 }
 
-/// Takes a `ProviderConfig` and produces a boxed provider instance.
+/// Creates a dynamic auth provider based on the given provider config.
 pub fn create_auth_provider(config: &ProviderConfig) -> Box<dyn Provider> {
     match config {
-        ProviderConfig::EcmwfApiAuthConfig(config) => {
-            Box::new(EcmwfApiProvider::new(config)) as Box<dyn Provider>
-        }
-        ProviderConfig::JWTAuthConfig(config) => {
-            Box::new(JWTProvider::new(config)) as Box<dyn Provider>
-        }
-        ProviderConfig::OpenIDOfflineAuthConfig(config) => {
-            Box::new(OpenIDOfflineProvider::new(config)) as Box<dyn Provider>
-        }
+        ProviderConfig::EcmwfApiAuthConfig(cfg) => Box::new(EcmwfApiProvider::new(cfg)),
+        ProviderConfig::JWTAuthConfig(cfg) => Box::new(JWTProvider::new(cfg)),
+        ProviderConfig::OpenIDOfflineAuthConfig(cfg) => Box::new(OpenIDOfflineProvider::new(cfg)),
     }
 }
 
-/// Takes an `AugmenterConfig` and produces a boxed augmenter instance.
+/// Creates a dynamic auth augmenter based on the given augmenter config.
 pub fn create_auth_augmenter(config: &AugmenterConfig) -> Box<dyn Augmenter> {
     match config {
-        AugmenterConfig::LDAPAugmenterConfig(config) => {
-            Box::new(self::ldap_augmenter::LDAPAugmenter::new(config)) as Box<dyn Augmenter>
+        AugmenterConfig::LDAPAugmenterConfig(cfg) => {
+            Box::new(ldap_augmenter::LDAPAugmenter::new(cfg))
         }
     }
 }
 
-/// The main Auth struct holds multiple providers and augmenters, plus
-/// a reference to the store for tokens.
-///
-/// - `providers`: A list of possible ways to authenticate (JWT, ECMWF, Bearer tokens from DB, etc.).
-/// - `augmenters`: A list of ways to enrich user data if the realm matches (e.g., LDAP).
-/// - `token_store`: The store is also a provider, so it's appended as well.
+/// The main Auth struct, holding all providers and augmenters, plus a token store.
 pub struct Auth {
     pub providers: Vec<Box<dyn Provider>>,
     pub augmenters: Vec<Box<dyn Augmenter>>,
@@ -102,7 +85,7 @@ pub struct Auth {
 }
 
 impl Auth {
-    /// Creates a new `Auth` instance from the provider/augmenter configs and token store.
+    /// Constructs a new `Auth` with the given provider/augmenter configs, plus a reference to the token store.
     pub fn new(
         provider_config: &[ProviderConfig],
         augmenter_config: &[AugmenterConfig],
@@ -112,7 +95,6 @@ impl Auth {
         let providers = provider_config
             .iter()
             .map(create_auth_provider)
-            // Also treat the token store as a Bearer provider
             .chain(std::iter::once(
                 Box::new(token_store.clone()) as Box<dyn Provider>
             ))
@@ -131,14 +113,13 @@ impl Auth {
     /// Orchestrates authentication by:
     /// 1) Parsing the `Authorization` header.
     /// 2) Finding all providers that match the "type" in the header.
-    /// 3) Attempting to authenticate using each provider (in **sequence**, stopping on the first success**).
-    /// 4) If authenticated, run any augmenters that match the user's realm.
-    /// 5) Return `Some(User)` on success, or `None` on failure.
+    /// 3) Attempting to authenticate with each matching provider **in parallel** (to avoid blocking on a slow/offline one).
+    /// 4) Once all complete, we pick the first success in provider order.
+    /// 5) If successfully authenticated, run augmenters matching the user's realm.
+    /// 6) Return `Some(User)` on success, or `None` on failure.
     pub async fn authenticate(&self, auth_header: &str, ip: &str) -> Option<User> {
-        // Example: "Bearer <token_value>"
         let parts: Vec<&str> = auth_header.split_whitespace().collect();
         if parts.len() != 2 {
-            // Possibly a misconfigured or missing header
             warn!("Authorization header invalid format: '{}'", auth_header);
             return None;
         }
@@ -151,35 +132,41 @@ impl Auth {
             auth_type, ip
         );
 
-        // Find providers that claim to handle this type (case-insensitive match).
+        // Find providers that match the auth_type
         let valid_providers: Vec<&Box<dyn Provider>> = self
             .providers
             .iter()
-            .filter(|provider| provider.get_type().eq_ignore_ascii_case(auth_type))
+            .filter(|p| p.get_type().eq_ignore_ascii_case(auth_type))
             .collect();
 
         if valid_providers.is_empty() {
-            // We have no providers that match this auth_type => can't authenticate
             warn!("No providers found for auth type: '{}'", auth_type);
             return None;
         }
 
-        // We'll try each matching provider in sequence, stopping at the first success.
-        let mut first_successful_user: Option<User> = None;
-        for provider in valid_providers {
-            match provider.authenticate(auth_credentials).await {
+        // Spawn all provider authenticates in parallel via join_all.
+        let futures: Vec<_> = valid_providers
+            .iter()
+            .map(|provider| provider.authenticate(auth_credentials))
+            .collect();
+
+        let results = future::join_all(futures).await;
+
+        // Iterate over results in the same order as the providers were listed.
+        let mut user_opt: Option<User> = None;
+        for (provider, result) in valid_providers.iter().zip(results) {
+            match result {
                 Ok(user) => {
-                    // Found a valid user from this provider; log success and break.
                     info!(
                         "Provider '{}' authenticated user '{}'",
                         provider.get_name(),
                         user.username
                     );
-                    first_successful_user = Some(user);
+                    user_opt = Some(user);
                     break;
                 }
                 Err(e) => {
-                    debug!(
+                    warn!(
                         "Provider '{}' failed to authenticate: {}",
                         provider.get_name(),
                         e
@@ -188,8 +175,7 @@ impl Auth {
             }
         }
 
-        // If no providers succeeded, return None
-        let mut user = match first_successful_user {
+        let mut user = match user_opt {
             Some(u) => u,
             None => {
                 warn!("All providers failed; no authentication succeeded.");
@@ -197,8 +183,7 @@ impl Auth {
             }
         };
 
-        // Now run any augmenters that match the user's realm,
-        // to add roles/attributes from external sources (e.g., LDAP).
+        // If we have a user, run augmenters for that user's realm.
         let realm = user.realm.clone();
         let valid_augmenters = self
             .augmenters
@@ -226,8 +211,6 @@ impl Auth {
         }
 
         debug!("Final user object after augmentation: {:?}", user);
-
-        // Return the authenticated and augmented user
         Some(user)
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -12,13 +12,16 @@ pub mod ecmwfapi_provider;
 pub mod jwt_provider;
 pub mod ldap_augmenter;
 pub mod openid_offline_provider;
+pub mod plain_provider;
 
 use ecmwfapi_provider::{EcmwfApiProvider, EcmwfApiProviderConfig};
 use jwt_provider::{JWTAuthConfig, JWTProvider};
 use ldap_augmenter::LDAPAugmenterConfig;
 use openid_offline_provider::{OpenIDOfflineProvider, OpenIDOfflineProviderConfig};
+use plain_provider::{PlainAuthConfig, PlainAuthProvider};
 
-/// A config enum to select which provider we use (ECMWF API, JWT, OpenID Offline).
+
+/// A config enum to select which provider we use (ECMWF API, JWT, OpenID Offline, Plain).
 #[derive(Deserialize, Serialize, JsonSchema, Debug)]
 #[serde(tag = "type")]
 pub enum ProviderConfig {
@@ -30,6 +33,9 @@ pub enum ProviderConfig {
 
     #[serde(rename = "openid-offline")]
     OpenIDOfflineAuthConfig(OpenIDOfflineProviderConfig),
+
+    #[serde(rename = "plain")]
+    PlainAuthConfig(PlainAuthConfig),
 }
 
 /// A config enum to select which augmenter we use (LDAP, etc.).
@@ -64,6 +70,7 @@ pub fn create_auth_provider(config: &ProviderConfig) -> Box<dyn Provider> {
         ProviderConfig::EcmwfApiAuthConfig(cfg) => Box::new(EcmwfApiProvider::new(cfg)),
         ProviderConfig::JWTAuthConfig(cfg) => Box::new(JWTProvider::new(cfg)),
         ProviderConfig::OpenIDOfflineAuthConfig(cfg) => Box::new(OpenIDOfflineProvider::new(cfg)),
+        ProviderConfig::PlainAuthConfig(cfg) => Box::new(PlainAuthProvider::new(cfg)),
     }
 }
 

--- a/src/auth/ecmwfapi_provider.rs
+++ b/src/auth/ecmwfapi_provider.rs
@@ -1,13 +1,16 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::{debug, info};
 
 use super::User;
 use cached::proc_macro::cached;
-use inline_colorization::*;
+use reqwest;
 
-// --- Config
-
+/// The config needed for the ECMWF API provider:
+/// - `uri` indicates the who-am-i endpoint
+/// - `realm` is the user realm
+/// - `name` is this provider’s display name
 #[derive(Deserialize, Serialize, Debug, JsonSchema, Clone)]
 pub struct EcmwfApiProviderConfig {
     pub uri: String,
@@ -15,15 +18,18 @@ pub struct EcmwfApiProviderConfig {
     pub name: String,
 }
 
-// --- Provider
-
+/// A provider that queries the ECMWF API (`who-am-i`) endpoint to authenticate a token.
 pub struct EcmwfApiProvider {
     pub config: EcmwfApiProviderConfig,
 }
 
 impl EcmwfApiProvider {
+    /// Creates a new ECMWF API provider.
     pub fn new(config: &EcmwfApiProviderConfig) -> Self {
-        println!("  🔑 Creating {style_bold}{color_cyan}EcmwfApiAuth{style_reset}{color_reset} for realm {}", config.realm);
+        info!(
+            "Creating EcmwfApiAuth provider for realm '{}', name='{}'",
+            config.realm, config.name
+        );
         Self {
             config: config.clone(),
         }
@@ -32,6 +38,12 @@ impl EcmwfApiProvider {
 
 #[async_trait::async_trait]
 impl super::Provider for EcmwfApiProvider {
+    /// Provider type is typically "Bearer".
+    fn get_type(&self) -> &str {
+        "Bearer"
+    }
+
+    /// Makes an HTTP call to the ECMWF API to validate the token and retrieve user info.
     async fn authenticate(&self, token: &str) -> Result<User, String> {
         query(
             self.config.uri.to_string(),
@@ -41,31 +53,41 @@ impl super::Provider for EcmwfApiProvider {
         .await
     }
 
+    /// The display name for this provider, used in logs or debugging.
     fn get_name(&self) -> &str {
         &self.config.name
     }
-
-    fn get_type(&self) -> &str {
-        "Bearer"
-    }
 }
 
+/// This function calls the ECMWF `who-am-i` endpoint with the provided token.
+/// We cache results for 60 seconds.
 #[cached(time = 60, sync_writes = true)]
 async fn query(uri: String, token: String, realm: String) -> Result<User, String> {
     let client = reqwest::Client::new();
     let url = format!("{}/who-am-i?token={}", uri, token);
-    let res = client.get(&url).send().await;
-    match res {
-        Ok(response) if response.status().is_success() => {
-            let body = response.text().await.unwrap();
-            let user_info: Value = serde_json::from_str(&body).unwrap();
-            let username = user_info["uid"].as_str().unwrap_or_default().to_string();
 
-            let user = Ok(User::new(realm, username, None, None, None, None));
-            user
-        }
-        Ok(response) if response.status() == 403 => Err(format!("invalid API token")),
-        Ok(response) => Err(format!("unexpected status code: {}", response.status())),
-        Err(e) => Err(format!("error sending request: {}", e)),
+    debug!("Sending ECMWF who-am-i request to: {}", url);
+    let response = match client.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => return Err(format!("Error sending request: {}", e)),
+    };
+
+    if response.status().is_success() {
+        // Parse the JSON body
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("Error reading response body: {}", e))?;
+        let user_info: Value =
+            serde_json::from_str(&body).map_err(|e| format!("Error parsing JSON: {}", e))?;
+
+        let username = user_info["uid"].as_str().unwrap_or_default().to_string();
+
+        let user = User::new(realm, username, None, None, None, None);
+        Ok(user)
+    } else if response.status() == 403 {
+        Err("Invalid API token".to_string())
+    } else {
+        Err(format!("Unexpected status code: {}", response.status()))
     }
 }

--- a/src/auth/jwt_provider.rs
+++ b/src/auth/jwt_provider.rs
@@ -2,21 +2,15 @@ use std::collections::HashMap;
 
 use cached::proc_macro::cached;
 use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::{debug, info};
 
 use super::User;
-use inline_colorization::*;
-use jsonwebtoken::decode;
-use jsonwebtoken::decode_header;
-use jsonwebtoken::Algorithm;
-use jsonwebtoken::DecodingKey;
-use jsonwebtoken::Validation;
 
-// --- Config
-
+/// JWT config structure for external usage
 #[derive(Deserialize, Serialize, JsonSchema, Debug, Clone)]
 pub struct JWTAuthConfig {
     pub cert_uri: String,
@@ -25,12 +19,12 @@ pub struct JWTAuthConfig {
     pub iam_realm: String,
 }
 
-// --- Provider
-
+/// Provider that validates JWTs using downloaded keys (JWK) from `cert_uri`.
 pub struct JWTProvider {
     pub config: JWTAuthConfig,
 }
 
+/// Helper struct to read claims from the JWT.
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
     sub: String,
@@ -40,16 +34,18 @@ struct Claims {
     entitlements: Option<Vec<String>>,
 }
 
+/// Used to unify roles from different sections of the claim.
 #[derive(Debug, Serialize, Deserialize)]
 struct RolesContainer {
     roles: Vec<String>,
 }
 
 impl JWTProvider {
+    /// Creates a new JWTProvider with the given config.
     pub fn new(config: &JWTAuthConfig) -> Self {
-        println!(
-            "  🔑 Creating {style_bold}{color_cyan}JWTAuth{style_reset}{color_reset} for realm {}",
-            config.realm
+        info!(
+            "Creating JWTAuth provider for realm '{}', name='{}'",
+            config.realm, config.name
         );
         Self {
             config: config.clone(),
@@ -59,49 +55,55 @@ impl JWTProvider {
 
 #[async_trait::async_trait]
 impl super::Provider for JWTProvider {
+    /// For consistency, we treat these tokens as "Bearer" type.
     fn get_type(&self) -> &str {
         "Bearer"
     }
 
+    /// Authenticates a token by decoding its header, fetching the right key, and validating.
     async fn authenticate(&self, token: &str) -> Result<User, String> {
+        debug!(
+            "Attempting JWT decode for realm='{}', name='{}'",
+            self.config.realm, self.config.name
+        );
+
+        // Fetch the JWK set (cached)
         let certs = get_certs(self.config.cert_uri.to_string()).await?;
+        let header =
+            decode_header(token).map_err(|e| format!("Failed to decode JWT header: {}", e))?;
 
-        let header = match decode_header(token) {
-            Ok(header) => header,
-            Err(e) => return Err(format!("failed to decode JWT header: {}", e)),
-        };
-
+        // Match the expected algorithm
         let alg = match header.alg {
             Algorithm::RS256 => "RS256",
             Algorithm::HS512 => "HS512",
             Algorithm::RS512 => "RS512",
-            _ => return Err(format!("unsupported JWT algorithm: {:?}", header.alg)),
+            _ => return Err(format!("Unsupported JWT algorithm: {:?}", header.alg)),
         };
 
+        // Parse the downloaded JWKS
         let jwks: JwkSet = serde_json::from_str(&certs)
-            .map_err(|e| format!("failed to parse certificates: {}", e))?;
+            .map_err(|e| format!("Failed to parse certificates: {}", e))?;
 
-        let kid = header.kid.ok_or("missing kid in JWT header")?;
-
+        let kid = header.kid.ok_or("Missing 'kid' in JWT header")?;
         let jwk = jwks.find(&kid).ok_or(format!(
-            "failed to find certificate with matching kid {}",
+            "Failed to find certificate with matching kid {}",
             kid
         ))?;
 
-        let decoding_key = DecodingKey::from_jwk(&jwk).expect("failed to create decoding key");
+        let decoding_key = DecodingKey::from_jwk(&jwk)
+            .map_err(|_| "Failed to create decoding key from JWK".to_string())?;
 
         let mut validation = Validation::new(alg.parse::<Algorithm>().unwrap());
+        validation.validate_aud = false; // Possibly enable if you want to check "aud"
 
-        validation.validate_aud = false;
-        let decoded = match decode::<Claims>(token, &decoding_key, &validation) {
-            Ok(decoded) => decoded,
-            Err(e) => return Err(format!("failed to decode JWT: {}", e)),
-        };
+        let decoded = decode::<Claims>(token, &decoding_key, &validation)
+            .map_err(|e| format!("Failed to decode JWT: {}", e))?;
 
+        // Collect roles from various places
         let mut roles = decoded
             .claims
             .realm_access
-            .and_then(|realm_access| Some(realm_access.roles))
+            .map(|ra| ra.roles)
             .unwrap_or_default();
 
         roles.extend(decoded.claims.entitlements.unwrap_or_default());
@@ -110,11 +112,14 @@ impl super::Provider for JWTProvider {
                 roles.extend(roles_container.roles);
             }
         }
+
+        // Build the final `User` object
         let user = User::new(
             self.config.realm.to_string(),
             decoded.claims.sub,
             Some(roles),
             None,
+            // We store the 'scope' claim in user attributes under the provider name
             Some(HashMap::from([(
                 self.config.name.clone(),
                 decoded
@@ -130,25 +135,26 @@ impl super::Provider for JWTProvider {
         Ok(user)
     }
 
+    /// A display name for logs/debugging.
     fn get_name(&self) -> &str {
         &self.config.name
     }
 }
 
+/// Retrieves the certificates (JWKS) from a remote URI. Cached for 600s to avoid repeated fetches.
 #[cached(time = 600, sync_writes = true)]
 pub async fn get_certs(cert_uri: String) -> Result<String, String> {
     let res = reqwest::get(&cert_uri)
         .await
-        .map_err(|e| format!("failed to download certificates: {}", e))?;
+        .map_err(|e| format!("Failed to download certificates: {}", e))?;
 
     if res.status().is_success() {
         let json: Value = res
             .json()
             .await
-            .map_err(|e| format!("failed to download certificates: {}", e))?;
-
+            .map_err(|e| format!("Failed to parse certificate JSON: {}", e))?;
         Ok(json.to_string())
     } else {
-        Err(format!("failed to download certificates: {}", res.status()))
+        Err(format!("Failed to download certificates: {}", res.status()))
     }
 }

--- a/src/auth/ldap_augmenter.rs
+++ b/src/auth/ldap_augmenter.rs
@@ -1,17 +1,14 @@
 use async_trait::async_trait;
 use cached::proc_macro::cached;
-use inline_colorization::*;
-use ldap3::LdapConnAsync;
-use ldap3::Scope;
-use ldap3::SearchEntry;
+use ldap3::{LdapConnAsync, Scope, SearchEntry};
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde::Serialize;
-
-use crate::models::User;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
 
 use super::Augmenter;
+use crate::models::User;
 
+/// Configuration required to connect to LDAP and fetch user roles.
 #[derive(Deserialize, Serialize, JsonSchema, Debug, Hash, PartialEq, Eq, Clone)]
 pub struct LDAPAugmenterConfig {
     pub name: String,
@@ -23,19 +20,25 @@ pub struct LDAPAugmenterConfig {
     pub ldap_password: String,
 }
 
+/// An augmenter that queries LDAP for additional user roles.
 pub struct LDAPAugmenter {
     config: LDAPAugmenterConfig,
 }
 
 impl LDAPAugmenter {
+    /// Creates a new LDAPAugmenter with the given config.
     pub fn new(config: &LDAPAugmenterConfig) -> LDAPAugmenter {
-        println!("  🏷️  Creating {style_bold}{color_cyan}LDAPAugmenter{style_reset}{color_reset} for realm {}", config.realm);
+        info!(
+            "Creating LDAPAugmenter for realm='{}', name='{}'",
+            config.realm, config.name
+        );
         LDAPAugmenter {
             config: config.clone(),
         }
     }
 }
 
+/// A helper that attempts to parse out the "CN" component from a full LDAP DN string.
 fn parse_cn(role: &str) -> Option<String> {
     role.split(',').find_map(|part| {
         let mut split = part.splitn(2, '=');
@@ -46,16 +49,24 @@ fn parse_cn(role: &str) -> Option<String> {
     })
 }
 
+/// This function looks up user roles in LDAP, caching results for 120 seconds.
+/// We bind with a service account, search for the user by `uid`, and parse "memberOf" attributes.
 #[cached(time = 120, sync_writes = true)]
 async fn retrieve_ldap_user_roles(
     config: LDAPAugmenterConfig,
     uid: String,
 ) -> Result<Vec<String>, String> {
+    debug!(
+        "Connecting to LDAP at {}, searching for user CN={}",
+        config.uri, uid
+    );
+
     let (conn, mut ldap) = LdapConnAsync::new(&config.uri)
         .await
         .map_err(|e| e.to_string())?;
     ldap3::drive!(conn);
 
+    // We do a simple bind using the configured service account
     let bind_dn = format!(
         "CN={},OU=Connectors,OU=Service Accounts,DC=ecmwf,DC=int",
         &config.ldap_user
@@ -67,7 +78,7 @@ async fn retrieve_ldap_user_roles(
         .map_err(|e| e.to_string())?;
 
     let search_filter = format!("(&(objectClass=person)(cn={}))", uid);
-    let (result, _res) = ldap
+    let (results, _res) = ldap
         .search(
             &config.search_base,
             Scope::Subtree,
@@ -80,12 +91,17 @@ async fn retrieve_ldap_user_roles(
         .map_err(|e| e.to_string())?;
 
     let mut roles = Vec::new();
-    for entry in result {
+    for entry in results {
         let search_entry = SearchEntry::construct(entry);
         if let Some(member_of) = search_entry.attrs.get("memberOf") {
-            for role in member_of {
-                if config.filter.as_deref().map_or(true, |f| role.contains(f)) {
-                    if let Some(cn) = parse_cn(role) {
+            for role_dn in member_of {
+                // If a filter is provided, only capture roles containing that string
+                let passes_filter = config
+                    .filter
+                    .as_deref()
+                    .map_or(true, |f| role_dn.contains(f));
+                if passes_filter {
+                    if let Some(cn) = parse_cn(role_dn) {
                         roles.push(cn);
                     }
                 }
@@ -98,33 +114,47 @@ async fn retrieve_ldap_user_roles(
 
 #[async_trait]
 impl Augmenter for LDAPAugmenter {
+    /// The display name for logs.
     fn get_name(&self) -> &str {
         &self.config.name
     }
 
+    /// The realm this augmenter applies to.
     fn get_realm(&self) -> &str {
         &self.config.realm
     }
 
+    /// The type is "ldap", though we don't typically match on this for augmentation.
     fn get_type(&self) -> &str {
         "ldap"
     }
 
+    /// Adds additional roles to the user from LDAP, if the realms match.
     async fn augment(&self, user: &mut User) -> Result<(), String> {
         if user.realm != self.get_realm() {
+            // Using panic is a bit harsh in production code, but we'll leave as-is for clarity.
             panic!(
-                "Trying to authorize a user in the wrong realm, expected {}, got {}",
+                "Attempted to augment user in the wrong realm. Expected '{}', got '{}'",
                 self.get_realm(),
                 user.realm
             );
         }
 
+        debug!("Retrieving LDAP roles for user '{}'", user.username);
         match retrieve_ldap_user_roles(self.config.clone(), user.username.clone()).await {
             Ok(roles) => {
+                debug!(
+                    "Fetched {} roles from LDAP for user '{}'",
+                    roles.len(),
+                    user.username
+                );
                 user.roles.extend(roles);
                 Ok(())
             }
-            Err(err) => Err(format!("Failed to retrieve LDAP user roles: {:?}", err)),
+            Err(err) => {
+                warn!("Failed to retrieve LDAP user roles: {}", err);
+                Err(format!("Failed to retrieve LDAP user roles: {}", err))
+            }
         }
     }
 }

--- a/src/auth/plain_provider.rs
+++ b/src/auth/plain_provider.rs
@@ -1,0 +1,103 @@
+use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine as _};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use super::{Provider, User};
+
+/// PlainAuthConfig defines the data for Basic authentication.
+#[derive(Deserialize, Serialize, Debug, JsonSchema, Clone)]
+pub struct PlainAuthConfig {
+    /// A friendly name for logs.
+    pub name: String,
+    /// The realm associated with this provider.
+    pub realm: String,
+    /// A list of username/password pairs.
+    pub users: Vec<PlainUserEntry>,
+}
+
+/// Represents a single user entry (username + password).
+#[derive(Deserialize, Serialize, Debug, JsonSchema, Clone)]
+pub struct PlainUserEntry {
+    pub username: String,
+    pub password: String,
+}
+
+/// A `PlainAuthProvider` that implements Basic authentication by
+/// comparing credentials to the user list in `PlainAuthConfig`.
+pub struct PlainAuthProvider {
+    pub config: PlainAuthConfig,
+}
+
+impl PlainAuthProvider {
+    /// Create a new `PlainAuthProvider` from the config struct.
+    pub fn new(config: &PlainAuthConfig) -> Self {
+        Self {
+            config: config.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for PlainAuthProvider {
+    /// The display name for logs/debug.  
+    fn get_name(&self) -> &str {
+        &self.config.name
+    }
+
+    /// Return "Basic" so that `Auth::authenticate` will match
+    /// `auth_type == "Basic"` to this provider.
+    fn get_type(&self) -> &str {
+        "Basic"
+    }
+
+    /// Decode the credentials (base64-encoded "username:password") and check
+    /// against the config’s user list. Return a `User` on success.
+    async fn authenticate(&self, credentials: &str) -> Result<User, String> {
+        // 1) Decode base64 -> bytes
+        let decoded_bytes = match general_purpose::STANDARD.decode(credentials) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("Base64 decode error: {}", e);
+                return Err("Invalid base64 in Basic auth".to_string());
+            }
+        };
+
+        // 2) Convert bytes -> UTF-8 string
+        let decoded_str = match String::from_utf8(decoded_bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("Invalid UTF-8 in Basic auth: {}", e);
+                return Err("Invalid UTF-8 in Basic auth".to_string());
+            }
+        };
+
+        // 3) Split into "username:password"
+        let mut parts = decoded_str.splitn(2, ':');
+        let user_part = parts.next().unwrap_or("");
+        let pass_part = parts.next().unwrap_or("");
+
+        if user_part.is_empty() {
+            return Err("No username in Basic credentials".to_string());
+        }
+
+        // 4) Compare with the user list in config
+        debug!("Basic auth attempt for user '{}'", user_part);
+        for entry in &self.config.users {
+            if entry.username == user_part && entry.password == pass_part {
+                // Found a match! Return a new user object.
+                return Ok(User::new(
+                    self.config.realm.clone(),
+                    user_part.to_string(),
+                    None, // roles
+                    None, // attributes
+                    None, // scopes
+                    Some(1),
+                ));
+            }
+        }
+
+        Err("Wrong username or password".to_string())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,16 +14,6 @@ pub enum Config {
     ConfigV1(ConfigV1),
 }
 
-/// This struct holds the logging settings for the application.
-///
-/// - `level`: The log verbosity level (trace, debug, info, warn, error).
-/// - `format`: The output format ("console" or "json").
-#[derive(Deserialize, Serialize, Debug, JsonSchema)]
-pub struct LoggingConfig {
-    pub level: String,
-    pub format: String,
-}
-
 /// This struct represents the entire configuration for version 1.0.0.
 ///
 /// It includes the token store, any services, providers, augmenters,
@@ -95,4 +85,14 @@ pub struct ServiceConfig {
 pub enum TokenStoreConfig {
     #[serde(rename = "mongo")]
     MongoDB(MongoDBConfig),
+}
+
+/// This struct holds the logging settings for the application.
+///
+/// - `level`: The log verbosity level (trace, debug, info, warn, error).
+/// - `format`: The output format ("console" or "json").
+#[derive(Deserialize, Serialize, Debug, JsonSchema)]
+pub struct LoggingConfig {
+    pub level: String,
+    pub format: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,21 +1,33 @@
-use crate::auth::AugmenterConfig;
-use crate::auth::ProviderConfig;
+use crate::auth::{AugmenterConfig, ProviderConfig};
 use crate::store::mongodb_store::MongoDBConfig;
-use figment::providers::Format;
-use figment::providers::Yaml;
+use figment::providers::{Format, Yaml};
 use figment::Figment;
-use schemars::schema_for;
-use schemars::JsonSchema;
-use serde::Deserialize;
-use serde::Serialize;
+use schemars::{schema_for, JsonSchema};
+use serde::{Deserialize, Serialize};
 
+/// This enum defines the application config
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "version")]
 pub enum Config {
+    /// Our first version of the config.
     #[serde(rename = "1.0.0")]
     ConfigV1(ConfigV1),
 }
 
+/// This struct holds the logging settings for the application.
+///
+/// - `level`: The log verbosity level (trace, debug, info, warn, error).
+/// - `format`: The output format ("console" or "json").
+#[derive(Deserialize, Serialize, Debug, JsonSchema)]
+pub struct LoggingConfig {
+    pub level: String,
+    pub format: String,
+}
+
+/// This struct represents the entire configuration for version 1.0.0.
+///
+/// It includes the token store, any services, providers, augmenters,
+/// bind address, JWT settings, and logging preferences.
 #[derive(Deserialize, Serialize, Debug, JsonSchema)]
 pub struct ConfigV1 {
     pub store: TokenStoreConfig,
@@ -26,38 +38,41 @@ pub struct ConfigV1 {
     pub bind_address: String,
     pub jwt: JWTConfig,
     pub include_legacy_headers: Option<bool>,
+    pub logging: LoggingConfig,
 }
 
+/// Loads the config from `./config.yaml` and returns a `ConfigV1`.
+/// If loading fails, it prints an error and exits the process.
 pub fn load_config() -> ConfigV1 {
+    // We use `Figment` to load and parse config.yaml
     let figment = Figment::new().merge(Yaml::file("./config.yaml"));
-
     let config = figment.extract::<Config>();
 
     let config = match config {
         Ok(config) => config,
         Err(e) => {
+            // We haven't initialized logging yet, so eprintln is safer.
             eprintln!("Error loading configuration: {}", e);
             std::process::exit(1);
         }
     };
 
+    // If we have multiple versions of config, match on them here.
     match config {
-        Config::ConfigV1(c) => {
-            // println!("Loaded configuration: {:?}", c);
-            c
-        }
+        Config::ConfigV1(c) => c,
     }
-
-    // handle configuration migration between versions here when necessary
 }
 
-pub fn print_schema() -> () {
+/// Prints the JSON schema for this config to stdout.
+/// Useful for generating schema docs or validations externally.
+pub fn print_schema() {
     let schema = schema_for!(Config);
     println!("{}", serde_json::to_string_pretty(&schema).unwrap());
 }
 
 // --- Subconfigs
 
+/// JWT settings to use for token generation and validation.
 #[derive(Deserialize, Serialize, JsonSchema, Debug)]
 pub struct JWTConfig {
     pub iss: String,
@@ -66,12 +81,15 @@ pub struct JWTConfig {
     pub secret: String,
 }
 
+/// Each `ServiceConfig` holds the name of the service and a list of scopes.
 #[derive(Deserialize, Serialize, JsonSchema, Debug)]
 pub struct ServiceConfig {
     pub name: String,
     pub scopes: Vec<String>,
 }
 
+/// Defines which token store to use (Mongo, etc.).
+/// Additional store types can be added in the future.
 #[derive(Deserialize, Serialize, JsonSchema, Debug)]
 #[serde(tag = "type")]
 pub enum TokenStoreConfig {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,43 @@
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+use crate::config::LoggingConfig;
+
+pub fn init_logging(logging_config: &LoggingConfig) {
+    // Parse level string -> LevelFilter
+    let level_filter = match logging_config.level.to_lowercase().as_str() {
+        "trace" => LevelFilter::TRACE,
+        "debug" => LevelFilter::DEBUG,
+        "warn" => LevelFilter::WARN,
+        "error" => LevelFilter::ERROR,
+        // default to INFO
+        _ => LevelFilter::INFO,
+    };
+
+    // This can be used to allow env-based overrides, plus the default:
+    let filter_layer = EnvFilter::default().add_directive(level_filter.into());
+
+    match logging_config.format.to_lowercase().as_str() {
+        "json" => {
+            // JSON output
+            tracing_subscriber::registry()
+                .with(filter_layer)
+                .with(fmt::layer().json()) // structured JSON
+                .init();
+        }
+        "console" => {
+            // Human-readable console output with ANSI colors
+            tracing_subscriber::registry()
+                .with(filter_layer)
+                .with(fmt::layer().pretty())
+                .init();
+        }
+        _ => {
+            // Fallback to console if unknown
+            tracing_subscriber::registry()
+                .with(filter_layer)
+                .with(fmt::layer().pretty())
+                .init();
+        }
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::auth::Provider;
 use crate::config::TokenStoreConfig;
@@ -58,7 +58,7 @@ impl Provider for Arc<dyn Store> {
                 Ok(user)
             }
             Ok(None) => {
-                warn!("Token not found in store.");
+                debug!("Token not found in store.");
                 Err("Token not found".to_string())
             }
             Err(e) => {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,41 +1,70 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use tracing::{debug, error, info, warn};
+
 use crate::auth::Provider;
 use crate::config::TokenStoreConfig;
 use crate::models::{Token, User};
-use async_trait::async_trait;
 
-//The Store trait itself
+/// The `Store` trait abstracts our token storage.
+/// Different implementations (e.g., MongoDB) can fulfill this.
 #[async_trait]
 pub trait Store: Send + Sync {
+    /// Adds a token for a given user, with a specified TTL (expiry).
     async fn add_token(&self, token: &Token, user: &User, expiry: i64) -> Result<(), String>;
+
+    /// Retrieves all tokens associated with a user.
     async fn get_tokens(&self, user: &User) -> Result<Vec<Token>, String>;
+
+    /// Looks up a user by token string.
     async fn get_user(&self, token: &str) -> Result<Option<User>, String>;
+
+    /// Deletes a token from the store.
     async fn delete_token(&self, token: &str) -> Result<(), String>;
 }
 
+/// Creates a store implementation based on the `TokenStoreConfig`.
+/// If creation fails, we log an error and exit.
 pub async fn create_store(config: &TokenStoreConfig) -> Arc<dyn Store> {
     match config {
         TokenStoreConfig::MongoDB(mongo_config) => {
-            // Call into the MongoDBStore
+            // Attempt to create a MongoDB-backed store.
             match crate::store::mongodb_store::MongoDBStore::new(mongo_config).await {
-                Ok(store) => Arc::new(store),
+                Ok(store) => {
+                    info!("Successfully created MongoDB store.");
+                    Arc::new(store)
+                }
                 Err(e) => {
-                    eprintln!("💥 Failed to create store: {}", e);
+                    error!("Failed to create MongoDB store: {}", e);
                     std::process::exit(1);
                 }
             }
-        } // More store types can be added here
+        } // If we add more store types in the future, we can handle them here.
     }
 }
 
+/// We also implement `Provider` for any `Arc<dyn Store>`.
+/// This means the `Store` can be used as an Auth Provider (by token).
 #[async_trait]
 impl Provider for Arc<dyn Store> {
+    /// If we have a token, we try to retrieve the associated `User`.
+    /// If `None` is returned, we treat it as "token not found".
     async fn authenticate(&self, token: &str) -> Result<User, String> {
+        debug!("Authenticating using token-store with token='{}'", token);
         match self.get_user(token).await {
-            Ok(Some(user)) => Ok(user),
-            Ok(None) => Err("Token not found".to_string()),
-            Err(e) => Err(e),
+            Ok(Some(user)) => {
+                debug!("Token found, returning user.");
+                Ok(user)
+            }
+            Ok(None) => {
+                warn!("Token not found in store.");
+                Err("Token not found".to_string())
+            }
+            Err(e) => {
+                error!("Error while getting user by token: {}", e);
+                Err(e)
+            }
         }
     }
 
@@ -43,6 +72,8 @@ impl Provider for Arc<dyn Store> {
         "token-store"
     }
 
+    /// The store acts as a "Bearer" provider,
+    /// so we match the "Bearer" type in `Auth::authenticate`.
     fn get_type(&self) -> &str {
         "Bearer"
     }


### PR DESCRIPTION
🛑 Note: This branch is based on PR #13 (pending approval). It should be reviewed after that PR is merged.

**Changes**

- Added PlainAuthProvider in plain_provider.rs, implementing the Provider trait.
- Added PlainAuthConfig struct, allowing multiple users with plaintext passwords.
- Updated ProviderConfig enum to support type: "plain" authentication.
- Integrated PlainAuthProvider into create_auth_provider(), enabling automatic usage when "plain" is specified in config.yaml.

This should resolve #6 