### PR TITLE
Add /providers Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authotron"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aide",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authotron"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aide",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authotron"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod models;
 mod store;
 mod utils;
+mod providers;
 
 use std::collections::HashMap;
 use std::env;
@@ -204,6 +205,7 @@ async fn main() {
         .route("/token", get(create_token))
         .route("/tokens", get(get_tokens))
         .route("/token/:token", delete(delete_token))
+        .route("/providers", get(providers::list_providers))
         .route("/health", get(health_check))
         .with_state(state);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod auth;
 mod config;
 mod models;
+mod providers;
 mod store;
 mod utils;
-mod providers;
 
 use std::collections::HashMap;
 use std::env;

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,8 +1,11 @@
-use axum::{extract::{ConnectInfo, State}, Json};
+use crate::AppState;
+use axum::{
+    extract::{ConnectInfo, State},
+    Json,
+};
 use serde_json::{json, Value};
 use std::net::SocketAddr;
 use tracing::{debug, info};
-use crate::AppState;
 
 /// GET /providers endpoint: returns only the provider "name" and "type" fields
 /// by converting each provider config into JSON and extracting the fields.
@@ -19,8 +22,8 @@ pub async fn list_providers(
         .iter()
         .map(|provider| {
             // Convert the provider config to a serde_json::Value.
-            let provider_json = serde_json::to_value(provider)
-                .expect("Failed to serialize provider config");
+            let provider_json =
+                serde_json::to_value(provider).expect("Failed to serialize provider config");
             if let Value::Object(mut map) = provider_json {
                 // Remove all keys except for "name" and "type".
                 let name = map.remove("name").unwrap_or_default();

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -7,11 +7,11 @@ use serde_json::{json, Value};
 use std::net::SocketAddr;
 use tracing::{debug, info};
 
-/// GET /providers endpoint: returns only the provider "name" and "type" fields
+/// GET /providers endpoint: returns only the provider "name", "type" and "realm" fields
 /// by converting each provider config into JSON and extracting the fields.
 pub async fn list_providers(
     State(state): State<AppState>,
-    ConnectInfo(client_addr): ConnectInfo<SocketAddr>, // Extract client IP
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
 ) -> Json<Value> {
     let client_ip = client_addr.ip();
     info!("Received request for provider list from IP: {}", client_ip);
@@ -21,16 +21,23 @@ pub async fn list_providers(
         .providers
         .iter()
         .map(|provider| {
-            // Convert the provider config to a serde_json::Value.
             let provider_json =
                 serde_json::to_value(provider).expect("Failed to serialize provider config");
             if let Value::Object(mut map) = provider_json {
-                // Remove all keys except for "name" and "type".
                 let name = map.remove("name").unwrap_or_default();
                 let provider_type = map.remove("type").unwrap_or_default();
+                // Extract realm: check for "realm" first, then fallback to "iam_realm"
+                let realm = if let Some(r) = map.remove("realm") {
+                    r
+                } else if let Some(r) = map.remove("iam_realm") {
+                    r
+                } else {
+                    Value::Null
+                };
                 json!({
                     "name": name,
                     "type": provider_type,
+                    "realm": realm,
                 })
             } else {
                 debug!("Provider configuration was not an object: {:?}", provider);

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,0 +1,45 @@
+use axum::{extract::{ConnectInfo, State}, Json};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use tracing::{debug, info};
+use crate::AppState;
+
+/// GET /providers endpoint: returns only the provider "name" and "type" fields
+/// by converting each provider config into JSON and extracting the fields.
+pub async fn list_providers(
+    State(state): State<AppState>,
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>, // Extract client IP
+) -> Json<Value> {
+    let client_ip = client_addr.ip();
+    info!("Received request for provider list from IP: {}", client_ip);
+
+    let providers: Vec<Value> = state
+        .config
+        .providers
+        .iter()
+        .map(|provider| {
+            // Convert the provider config to a serde_json::Value.
+            let provider_json = serde_json::to_value(provider)
+                .expect("Failed to serialize provider config");
+            if let Value::Object(mut map) = provider_json {
+                // Remove all keys except for "name" and "type".
+                let name = map.remove("name").unwrap_or_default();
+                let provider_type = map.remove("type").unwrap_or_default();
+                json!({
+                    "name": name,
+                    "type": provider_type,
+                })
+            } else {
+                debug!("Provider configuration was not an object: {:?}", provider);
+                json!({})
+            }
+        })
+        .collect();
+
+    info!(
+        "Returning sanitized provider list to IP: {}. Number of providers: {}",
+        client_ip,
+        providers.len()
+    );
+    Json(json!({ "providers": providers }))
+}


### PR DESCRIPTION
This PR introduces a new endpoint (/providers) that enables external services to discover available authentication providers without exposing any sensitive data. The endpoint automatically extracts only the provider “name” and “type” from our internal configuration. 