### PR TITLE
Feature/improved auth

### DIFF
--- a/src/auth/auth.rs
+++ b/src/auth/auth.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc
+use std::sync::Arc;
 
 use crate::config::AuthConfig;
 use crate::models::User;

--- a/src/auth/ecmwfapi_provider.rs
+++ b/src/auth/ecmwfapi_provider.rs
@@ -39,6 +39,10 @@ impl super::Provider for EcmwfApiProvider {
         "Bearer"
     }
 
+    fn get_realm(&self) -> Option<&str> {
+        Some(&self.config.realm)
+    }
+
     async fn authenticate(&self, token: &str) -> Result<User, String> {
         query(
             self.config.uri.clone(),

--- a/src/auth/jwt_provider.rs
+++ b/src/auth/jwt_provider.rs
@@ -60,6 +60,10 @@ impl super::Provider for JWTProvider {
         "Bearer"
     }
 
+    fn get_realm(&self) -> Option<&str> {
+        Some(&self.config.realm)
+    }
+
     /// Authenticates a token by decoding its header, fetching the right key, and validating.
     async fn authenticate(&self, token: &str) -> Result<User, String> {
         debug!(

--- a/src/auth/openid_offline_provider.rs
+++ b/src/auth/openid_offline_provider.rs
@@ -133,6 +133,10 @@ impl Provider for OpenIDOfflineProvider {
         "Bearer"
     }
 
+    fn get_realm(&self) -> Option<&str> {
+        Some(&self.config.realm)
+    }
+
     fn get_name(&self) -> &str {
         &self.config.name
     }

--- a/src/auth/plain_provider.rs
+++ b/src/auth/plain_provider.rs
@@ -53,6 +53,11 @@ impl Provider for PlainAuthProvider {
         "Basic"
     }
 
+    /// Return the realm associated with this provider.
+    fn get_realm(&self) -> Option<&str> {
+        Some(&self.config.realm)
+    }
+
     /// Decode the credentials (base64-encoded "username:password") and check
     /// against the config’s user list. Return a `User` on success.
     async fn authenticate(&self, credentials: &str) -> Result<User, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ async fn authenticate(
         .status(StatusCode::OK)
         .header("Authorization", format!("Bearer {}", jwt))
         .body(Body::from("Authenticated successfully"))
-        .map_err(|e| HTTPError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| HTTPError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string(), None))?;
 
     if state.config.include_legacy_headers.unwrap_or(false) {
         let headers = response_builder.headers_mut();

--- a/src/utils/http_helpers.rs
+++ b/src/utils/http_helpers.rs
@@ -1,51 +1,65 @@
-use std::net::SocketAddr;
-
+use crate::models::User;
+use crate::AppState;
 use axum::async_trait;
 use axum::extract::{ConnectInfo, FromRequestParts};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use http::request::Parts;
+use std::net::SocketAddr;
+use tracing::warn;
 
-use crate::models::User;
-use crate::AppState;
-
-/// A general purpose HTTP error type that can be converted into an `IntoResponse`.
+/// HTTPError is our custom error type returned by our request extractor.
+/// It now carries an optional challenge string that is used to dynamically
+/// populate the WWW-Authenticate header for unauthorized responses.
 pub struct HTTPError {
     status: StatusCode,
     message: String,
+    challenge: Option<String>,
 }
 
 impl HTTPError {
-    /// Creates a new HTTP error with the given status code and message.
-    pub fn new(status: StatusCode, message: impl Into<String>) -> Self {
+    /// Create a new HTTPError with a status, message, and optional challenge.
+    pub fn new(status: StatusCode, message: impl Into<String>, challenge: Option<String>) -> Self {
         HTTPError {
             status,
             message: message.into(),
+            challenge,
         }
     }
 }
 
-/// Converts our `HTTPError` into an HTTP response.
+/// Convert the HTTPError into an HTTP response.
+/// If the status is 401 Unauthorized and a challenge is provided,
+/// we include it as the WWW-Authenticate header.
 impl IntoResponse for HTTPError {
     fn into_response(self) -> Response {
         let body = format!("{{\"error\": \"{}\"}}", self.message);
-        Response::builder()
+        let mut builder = Response::builder()
             .status(self.status)
-            .header("Content-Type", "application/json")
-            .body(body.into())
-            .unwrap()
+            .header("Content-Type", "application/json");
+
+        if self.status == StatusCode::UNAUTHORIZED {
+            // If a challenge is provided, use it.
+            if let Some(challenge) = self.challenge {
+                builder = builder.header("WWW-Authenticate", challenge);
+            }
+        }
+
+        builder.body(body.into()).unwrap()
     }
 }
 
-/// Extractor implementation: tries to convert the request parts into a `User`.
-/// This uses the `authorization` header and calls `Auth::authenticate`.
+/// Implementation of the request extractor for User.
+/// When authentication fails, we return an HTTPError that includes a
+/// dynamic WWW-Authenticate challenge generated from the available providers.
 #[async_trait]
 impl FromRequestParts<AppState> for User {
     type Rejection = HTTPError;
     async fn from_request_parts<'a, 'b>(
-        parts: &'a mut http::request::Parts,
+        parts: &'a mut Parts,
         state: &'b AppState,
     ) -> Result<User, HTTPError> {
-        // Retrieve the Authorization header
+        // Extract the Authorization header.
         let auth_header = parts
             .headers
             .get("authorization")
@@ -53,33 +67,38 @@ impl FromRequestParts<AppState> for User {
             .unwrap_or("")
             .to_string();
 
-        // Retrieve the optional X-Auth-Realm header
+        // Extract the optional X-Auth-Realm header.
         let realm_filter = parts
             .headers
             .get("x-auth-realm")
             .and_then(|value| value.to_str().ok());
 
-        // Get the client IP for logging purposes
+        // Retrieve the client IP (for logging purposes).
         let client_ip = parts
             .extensions
             .get::<ConnectInfo<SocketAddr>>()
             .map(|ConnectInfo(addr)| addr.ip())
             .unwrap_or_else(|| {
-                tracing::warn!("Unable to determine client IP address.");
+                warn!("Unable to determine client IP address.");
                 "unknown".parse().unwrap()
             });
 
-        // Call the new authenticate function with the optional realm filter
+        // Attempt to authenticate using our Auth implementation.
         match state
             .auth
             .authenticate(&auth_header, &client_ip.to_string(), realm_filter)
             .await
         {
             Some(user) => Ok(user),
-            None => Err(HTTPError::new(
-                http::StatusCode::UNAUTHORIZED,
-                "Unauthorized access",
-            )),
+            None => {
+                // Generate a dynamic challenge header from the available providers.
+                let challenge = state.auth.generate_challenge_header();
+                Err(HTTPError::new(
+                    StatusCode::UNAUTHORIZED,
+                    "Unauthorized access",
+                    Some(challenge),
+                ))
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces several improvements to the authentication mechanism:

**Comma-Separated Credentials:**

- The authenticate function now parses comma-separated Authorization header values, allowing clients to supply multiple credentials (e.g., "Bearer token, Basic base64credentials"). 
- It normalizes schemes (mapping "plain" to "Basic") so that both "Basic" and "plain" are treated uniformly.

**Realm Filtering:**

- An optional X-Auth-Realm header is supported. When provided, only providers with a matching realm are considered during authentication.

**Dynamic Challenge Header:**

- Unauthorized responses now include a dynamically generated WWW-Authenticate header that lists the supported authentication schemes and their realms, based on the current provider configuration.