### PR TITLE
Feat/ecmwf token

### DIFF
--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -217,7 +217,9 @@ mod tests {
         let jwt_config = default_jwt_config();
         let token = user.to_jwt(&jwt_config);
         let claims = decode_claims(&token, &jwt_config);
-        let exp_claim = claims["exp"].as_i64().expect("exp claim should be an integer");
+        let exp_claim = claims["exp"]
+            .as_i64()
+            .expect("exp claim should be an integer");
         // Assert that the exp claim matches the custom exp attribute.
         assert_eq!(exp_claim, custom_exp);
     }

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -1,6 +1,8 @@
 use super::{
+    ecmwf_token_generator_provider::{
+        EcmwfTokenGeneratorProvider, EcmwfTokenGeneratorProviderConfig,
+    },
     ecmwfapi_provider::{EcmwfApiProvider, EcmwfApiProviderConfig},
-    ecmwf_token_generator_provider::{EcmwfTokenGeneratorProvider, EcmwfTokenGeneratorProviderConfig},
     jwt_provider::{JWTAuthConfig, JWTProvider},
     openid_offline_provider::{OpenIDOfflineProvider, OpenIDOfflineProviderConfig},
     plain_provider::{PlainAuthConfig, PlainAuthProvider},

--- a/src/providers/ecmwf_token_generator_provider.rs
+++ b/src/providers/ecmwf_token_generator_provider.rs
@@ -156,11 +156,9 @@ impl Provider for EcmwfTokenGeneratorProvider {
         }
 
         // Get access token from token generator
-        let access_token = get_access_token_from_generator(
-            self.config.clone(), 
-            credentials.to_string()
-        ).await?;
-        
+        let access_token =
+            get_access_token_from_generator(self.config.clone(), credentials.to_string()).await?;
+
         // Now authenticate with the access token
         self.jwt_auth.authenticate(&access_token).await
     }
@@ -202,8 +200,9 @@ mod tests {
 
         let result = validate_token_with_generator(
             create_test_config(server.url()),
-            "valid_token".to_string()
-        ).await;
+            "valid_token".to_string(),
+        )
+        .await;
 
         m.assert_async().await;
         assert!(result.is_ok(), "Expected successful validation");
@@ -222,8 +221,9 @@ mod tests {
 
         let result = validate_token_with_generator(
             create_test_config(server.url()),
-            "invalid_token".to_string()
-        ).await;
+            "invalid_token".to_string(),
+        )
+        .await;
 
         assert!(result.is_ok(), "Request should succeed");
         assert!(!result.unwrap(), "Expected token to be inactive");
@@ -238,10 +238,9 @@ mod tests {
             .create_async()
             .await;
 
-        let result = validate_token_with_generator(
-            create_test_config(server.url()),
-            "token".to_string()
-        ).await;
+        let result =
+            validate_token_with_generator(create_test_config(server.url()), "token".to_string())
+                .await;
 
         assert!(result.is_err(), "Expected error on HTTP 500");
     }
@@ -266,8 +265,9 @@ mod tests {
 
         let result = get_access_token_from_generator(
             create_test_config(server.url()),
-            "refresh_token_123".to_string()
-        ).await;
+            "refresh_token_123".to_string(),
+        )
+        .await;
 
         m.assert_async().await;
         assert!(result.is_ok(), "Expected successful token exchange");
@@ -285,8 +285,9 @@ mod tests {
 
         let result = get_access_token_from_generator(
             create_test_config(server.url()),
-            "refresh_token".to_string()
-        ).await;
+            "refresh_token".to_string(),
+        )
+        .await;
 
         assert!(result.is_err(), "Expected error on HTTP 401");
     }
@@ -306,11 +307,15 @@ mod tests {
 
         let result = provider.authenticate("invalid_token").await;
 
-        assert!(result.is_err(), "Expected authentication to fail for invalid token");
         assert!(
-            result.unwrap_err().contains("not valid according to ECMWF Token Generator"),
+            result.is_err(),
+            "Expected authentication to fail for invalid token"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .contains("not valid according to ECMWF Token Generator"),
             "Error should indicate validation failure"
         );
     }
-
 }

--- a/src/providers/jwt_provider.rs
+++ b/src/providers/jwt_provider.rs
@@ -38,7 +38,6 @@ struct Claims {
     /// Any additional claim fields we don't explicitly model.
     #[serde(flatten)]
     extra: HashMap<String, Value>,
-    
 }
 
 /// Used to unify roles from different sections of the claim.
@@ -114,10 +113,7 @@ impl Provider for JWTProvider {
 
         let claims = decoded.claims;
         // Collect roles from various places
-        let mut roles = claims
-            .realm_access
-            .map(|ra| ra.roles)
-            .unwrap_or_default();
+        let mut roles = claims.realm_access.map(|ra| ra.roles).unwrap_or_default();
 
         roles.extend(claims.entitlements.unwrap_or_default());
         if let Some(resource_access) = claims.resource_access {
@@ -284,7 +280,8 @@ mod tests {
     /// Test that additional, unspecified claims are preserved as user attributes.
     #[tokio::test]
     async fn test_jwt_provider_preserves_extra_claims() {
-        let jwks = r#"{"keys": [{"kty": "oct", "k": "c2VjcmV0", "alg": "HS512", "kid": "testkid"}]}"#;
+        let jwks =
+            r#"{"keys": [{"kty": "oct", "k": "c2VjcmV0", "alg": "HS512", "kid": "testkid"}]}"#;
         let mut server = Server::new_async().await;
         let m = server
             .mock("GET", "/")
@@ -328,6 +325,9 @@ mod tests {
 
         assert_eq!(user.username, "user1");
         assert_eq!(user.attributes.get("custom"), Some(&"abc".to_string()));
-        assert_eq!(user.attributes.get("nested"), Some(&"{\"flag\":true}".to_string()));
+        assert_eq!(
+            user.attributes.get("nested"),
+            Some(&"{\"flag\":true}".to_string())
+        );
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,6 +1,6 @@
 pub mod base;
-pub mod ecmwfapi_provider;
 pub mod ecmwf_token_generator_provider;
+pub mod ecmwfapi_provider;
 pub mod jwt_provider;
 pub mod openid_offline_provider;
 pub mod plain_provider;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -7,10 +7,10 @@ use authotron::metrics::Metrics;
 use authotron::routes::create_router;
 use authotron::state::AppState;
 use authotron::store::create_store;
+use axum::Router;
 use axum::body::Body;
 use axum::extract::ConnectInfo;
 use axum::http::{Method, Request};
-use axum::Router;
 use base64::{Engine as _, engine::general_purpose};
 use jsonwebtoken::{DecodingKey, TokenData, Validation, decode};
 use serde::{Deserialize, Serialize};
@@ -56,12 +56,10 @@ pub fn request_with_bearer(path: &str, token: &str, method: Method) -> Request<B
         .body(Body::empty())
         .expect("failed to build request");
 
-    request
-        .extensions_mut()
-        .insert(ConnectInfo(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-            0,
-        )));
+    request.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        0,
+    )));
 
     request
 }
@@ -75,12 +73,10 @@ pub fn request_with_basic(path: &str, credentials: &str, method: Method) -> Requ
         .body(Body::empty())
         .expect("failed to build request");
 
-    request
-        .extensions_mut()
-        .insert(ConnectInfo(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-            0,
-        )));
+    request.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        0,
+    )));
 
     request
 }

--- a/tests/ecmwf_token_generator_integration.rs
+++ b/tests/ecmwf_token_generator_integration.rs
@@ -1,7 +1,10 @@
 use authotron::config::{Config, ConfigV1};
 use axum::http::{Method, StatusCode};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use figment::{Figment, providers::{Format, Yaml}};
+use figment::{
+    Figment,
+    providers::{Format, Yaml},
+};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use mockito::{Matcher, Server};
 use serde_json::{Value, json};
@@ -72,8 +75,7 @@ fn build_jwks(kid: &str, secret: &[u8]) -> String {
 fn encode_hs512_token(claims: Value, kid: &str, secret: &[u8]) -> String {
     let mut header = Header::new(Algorithm::HS512);
     header.kid = Some(kid.to_string());
-    encode(&header, &claims, &EncodingKey::from_secret(secret))
-        .expect("Failed to encode JWT")
+    encode(&header, &claims, &EncodingKey::from_secret(secret)).expect("Failed to encode JWT")
 }
 
 fn example_claims(scope: &str) -> Value {
@@ -142,19 +144,30 @@ async fn integration_ecmwf_token_generator_exchanges_refresh_token() {
         })))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(json!({
-            "access_token": exchanged_access_token,
-            "expires_in": 300
-        }).to_string())
+        .with_body(
+            json!({
+                "access_token": exchanged_access_token,
+                "expires_in": 300
+            })
+            .to_string(),
+        )
         .create_async()
         .await;
 
-    let (app, config) = build_app(build_config(&server.url(), &format!("{}/jwks", server.url()))).await;
-    
+    let (app, config) = build_app(build_config(
+        &server.url(),
+        &format!("{}/jwks", server.url()),
+    ))
+    .await;
+
     // Perform authentication request
     let response = app
         .clone()
-        .oneshot(request_with_bearer("/authenticate", &refresh_token, Method::GET))
+        .oneshot(request_with_bearer(
+            "/authenticate",
+            &refresh_token,
+            Method::GET,
+        ))
         .await
         .expect("request should succeed");
 

--- a/tests/offline_integration.rs
+++ b/tests/offline_integration.rs
@@ -1,6 +1,9 @@
 use authotron::config::{Config, ConfigV1};
 use axum::http::{Method, StatusCode};
-use figment::{Figment, providers::{Format, Yaml}};
+use figment::{
+    Figment,
+    providers::{Format, Yaml},
+};
 use tower::ServiceExt;
 
 mod common;
@@ -76,7 +79,11 @@ async fn integration_plain_auth_flow() {
 
     let response = app
         .clone()
-        .oneshot(request_with_basic("/authenticate", "adam:admin", Method::GET))
+        .oneshot(request_with_basic(
+            "/authenticate",
+            "adam:admin",
+            Method::GET,
+        ))
         .await
         .expect("request should succeed");
 
@@ -122,7 +129,11 @@ async fn integration_plain_auth_realm_separation() {
 
     let response = app
         .clone()
-        .oneshot(request_with_basic("/authenticate", "adam:other", Method::GET))
+        .oneshot(request_with_basic(
+            "/authenticate",
+            "adam:other",
+            Method::GET,
+        ))
         .await
         .expect("request should complete");
 
@@ -141,5 +152,9 @@ async fn integration_plain_auth_realm_separation() {
     let claims = decode_claims(token, &config.jwt.secret);
 
     assert_eq!(claims.claims.roles.len(), 1);
-    assert!(claims.claims.roles.iter().all(|r| r == "user"), "Expected only 'user' role but got {:?}", claims.claims.roles);
+    assert!(
+        claims.claims.roles.iter().all(|r| r == "user"),
+        "Expected only 'user' role but got {:?}",
+        claims.claims.roles
+    );
 }


### PR DESCRIPTION
### Description
Follows #42 

Adds the ECMWF Keycloak wrapper provider. It checks the token against the validation endpoint, then exchanges the refresh token for an access token. Both cache for 4 minutes since the access tokens are valid for 5.

Additionally:

- no longer issues JWTs with expiry past the upstream JWT's expiry
- adds unmodeled claims from the upstream JWT to the Auth-o-tron JWT
- uses preferred_username as username (this allows us to add augmenters based on people's usernames)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 