### PR TITLE
fix(ci): publish docs to dedicated authotron space

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -99,22 +99,22 @@ jobs:
     with:
       artifact-id: ${{ needs.build-docs.outputs.artifact-id }}
       space: docs
-      name: dev-section
-      path: auth-o-tron/pull-requests
+      name: authotron
+      path: authotron/pull-requests
       link-tag: PREVIEW-PUBLISH-AUTH-O-TRON-DOCS
       link-text: "Docs Preview"
     secrets:
-      sites-token: ${{ secrets.ECMWF_SITES_DOCS_DEV_SECTION_TOKEN }}
+      sites-token: ${{ secrets.ECMWF_SITES_DOCS_AUTHOTRON_TOKEN }}
 
   preview-unpublish:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ecmwf/reusable-workflows/.github/workflows/pr-preview-unpublish.yml@5a1d1cb1442aa632f7823e4088d639b980627afc
     with:
       space: docs
-      name: dev-section
-      path: auth-o-tron/pull-requests
+      name: authotron
+      path: authotron/pull-requests
     secrets:
-      sites-token: ${{ secrets.ECMWF_SITES_DOCS_DEV_SECTION_TOKEN }}
+      sites-token: ${{ secrets.ECMWF_SITES_DOCS_AUTHOTRON_TOKEN }}
 
   compute-publish-id:
     if: >-
@@ -174,9 +174,9 @@ jobs:
     with:
       artifact-id: ${{ needs.build-docs.outputs.artifact-id }}
       space: docs
-      name: dev-section
-      path: auth-o-tron
+      name: authotron
+      path: authotron
       id: ${{ needs.compute-publish-id.outputs.publish-id }}
       softlink: ${{ github.event_name == 'push' && (github.ref_type == 'tag' && 'stable' || github.ref_name == 'main' && 'latest') || '' }}
     secrets:
-      sites-token: ${{ secrets.ECMWF_SITES_DOCS_DEV_SECTION_TOKEN }}
+      sites-token: ${{ secrets.ECMWF_SITES_DOCS_AUTHOTRON_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -100,7 +100,7 @@ jobs:
       artifact-id: ${{ needs.build-docs.outputs.artifact-id }}
       space: docs
       name: authotron
-      path: authotron/pull-requests
+      path: pull-requests
       link-tag: PREVIEW-PUBLISH-AUTH-O-TRON-DOCS
       link-text: "Docs Preview"
     secrets:
@@ -112,7 +112,7 @@ jobs:
     with:
       space: docs
       name: authotron
-      path: authotron/pull-requests
+      path: pull-requests
     secrets:
       sites-token: ${{ secrets.ECMWF_SITES_DOCS_AUTHOTRON_TOKEN }}
 
@@ -175,7 +175,7 @@ jobs:
       artifact-id: ${{ needs.build-docs.outputs.artifact-id }}
       space: docs
       name: authotron
-      path: authotron
+      path: ""
       id: ${{ needs.compute-publish-id.outputs.publish-id }}
       softlink: ${{ github.event_name == 'push' && (github.ref_type == 'tag' && 'stable' || github.ref_name == 'main' && 'latest') || '' }}
     secrets:


### PR DESCRIPTION
## Summary
Moves docs publishing from the shared `dev-section` space to a dedicated `authotron` space on ECMWF Sites. Docs will now be available at `sites.ecmwf.int/docs/authotron/` instead of `sites.ecmwf.int/docs/dev-section/auth-o-tron`.
## Changes
Updated `name`, `path`, and `sites-token` secret across all 3 publish jobs in `.github/workflows/docs.yaml`:
| Job | Before | After |
|-----|--------|-------|
| preview-publish | `dev-section/auth-o-tron/pull-requests` | `authotron/pull-requests` |
| preview-unpublish | `dev-section/auth-o-tron/pull-requests` | `authotron/pull-requests` |
| publish-docs | `dev-section/auth-o-tron` | `authotron` |
| secret | `ECMWF_SITES_DOCS_DEV_SECTION_TOKEN` | `ECMWF_SITES_DOCS_AUTHOTRON_TOKEN` |


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-62
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->