### PR TITLE
feat: derive Clone for AuthClient

### DIFF
--- a/authotron-client/src/lib.rs
+++ b/authotron-client/src/lib.rs
@@ -123,6 +123,7 @@ pub fn convert_email_key(auth_header: &str) -> String {
 
 /// HTTP client that calls auth-o-tron's `/authenticate` endpoint, decodes the
 /// returned JWT, and caches the result.
+#[derive(Clone)]
 pub struct AuthClient {
     http: Client,
     url: String,


### PR DESCRIPTION
## Summary

- Adds `#[derive(Clone)]` to `AuthClient` so it can be shared in Axum state without an extra `Arc` wrapper.

## Merge order
Merge this **before** `ecmwf/polytope-server#feat/unauthenticated-routes` (polytope-server depends on this branch).

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-64
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->