### PR TITLE
feat(metrics): build_info, series pre-init, process metrics, fallible render + fix readme logo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2331,6 +2337,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,8 +2367,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf",
  "thiserror 2.0.18",
 ]
@@ -2683,6 +2713,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2690,7 +2733,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3268,7 +3311,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![auth-o-tron logo](https://raw.githubusercontent.com/ecmwf/auth-o-tron/main/docs/logo-light.png)
+![auth-o-tron logo](https://raw.githubusercontent.com/ecmwf/auth-o-tron/main/authotron/docs/logo-light.png)
 
 <div align="center">
 

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -46,7 +46,7 @@ mongodb = "~3.5"
 figment = { version = "~0.10", features = ["yaml", "env"] }
 
 # Observability
-prometheus = "~0.14"
+prometheus = { version = "~0.14", features = ["process"] }
 tracing = "~0.1"
 tracing-subscriber = { version = "~0.3", features = ["env-filter", "json"] }
 

--- a/authotron/src/metrics/recorder.rs
+++ b/authotron/src/metrics/recorder.rs
@@ -11,7 +11,9 @@
 use prometheus::{
     CounterVec, Encoder, HistogramVec, Opts, Registry, TextEncoder,
     register_counter_vec_with_registry, register_histogram_vec_with_registry,
+    register_int_gauge_vec_with_registry,
 };
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 /// Trait for recording application metrics.
@@ -75,6 +77,33 @@ impl Metrics {
     /// Creates a new metrics instance with a Prometheus registry.
     pub fn new() -> Self {
         let registry = Arc::new(Registry::new());
+
+        // Build info: constant-1 gauge carrying the crate version as a label,
+        // for deploy annotations on dashboards (standard `*_build_info`
+        // convention). Prefixed `authotron_` to avoid colliding with other
+        // services' `build_info` series in a shared Prometheus. Not stored on
+        // the struct: the registry holds the registered clone, and the value
+        // is set once here and never changes.
+        let build_info = register_int_gauge_vec_with_registry!(
+            Opts::new(
+                "authotron_build_info",
+                "Build information; constant 1 with the crate version as a label"
+            ),
+            &["version"],
+            registry.clone()
+        )
+        .expect("Failed to register authotron_build_info");
+        build_info
+            .with_label_values(&[env!("CARGO_PKG_VERSION")])
+            .set(1);
+
+        // Process metrics (CPU, memory, open FDs) on the service's own
+        // registry. Linux-only: the collector reads /proc.
+        #[cfg(target_os = "linux")]
+        {
+            let collector = prometheus::process_collector::ProcessCollector::for_self();
+            let _ = registry.register(Box::new(collector));
+        }
 
         // Authentication metrics
         let auth_requests_total = register_counter_vec_with_registry!(
@@ -149,14 +178,81 @@ impl Metrics {
     }
 
     /// Renders all metrics in Prometheus text format.
-    pub fn render(&self) -> String {
+    ///
+    /// Returns an error if encoding fails so the scrape handler can surface a
+    /// 500 instead of panicking the process. The UTF-8 step is lossy and
+    /// cannot fail (Prometheus text exposition is ASCII).
+    pub fn render(&self) -> Result<String, prometheus::Error> {
         let encoder = TextEncoder::new();
         let metric_families = self.registry.gather();
         let mut buffer = Vec::new();
-        encoder
-            .encode(&metric_families, &mut buffer)
-            .expect("Failed to encode metrics");
-        String::from_utf8(buffer).expect("Metrics encoding produced invalid UTF-8")
+        encoder.encode(&metric_families, &mut buffer)?;
+        Ok(String::from_utf8_lossy(&buffer).into_owned())
+    }
+
+    /// Pre-initialise bounded label series to zero at startup so
+    /// `rate(...{result="error"}[5m]) > 0` alert rules evaluate against an
+    /// existing zero baseline instead of a missing series. Only label
+    /// combinations the code can actually emit are created: provider/augmenter
+    /// series from the configured set, auth failures only with
+    /// `realm="unknown"`, and auth successes with each configured realm.
+    ///
+    /// `providers` and `augmenters` are `(name, type, realm)` descriptors.
+    pub fn preinit_series(
+        &self,
+        providers: &[(String, String, String)],
+        augmenters: &[(String, String, String)],
+    ) {
+        for (name, provider_type, realm) in providers {
+            for result in ["success", "error", "timeout"] {
+                self.provider_attempts_total.with_label_values(&[
+                    name,
+                    provider_type,
+                    realm,
+                    result,
+                ]);
+            }
+            self.provider_duration_seconds
+                .with_label_values(&[name, provider_type, realm]);
+        }
+
+        for (name, augmenter_type, realm) in augmenters {
+            for result in ["success", "error"] {
+                self.augmenter_attempts_total.with_label_values(&[
+                    name,
+                    augmenter_type,
+                    realm,
+                    result,
+                ]);
+            }
+            self.augmenter_duration_seconds
+                .with_label_values(&[augmenter_type, realm]);
+        }
+
+        // Pre-resolution auth failures are only ever recorded with realm="unknown".
+        for result in ["no_auth_header", "invalid_header", "all_failed"] {
+            self.auth_requests_total
+                .with_label_values(&[result, "unknown"]);
+            self.auth_duration_seconds
+                .with_label_values(&[result, "unknown"]);
+        }
+
+        // Successful auth carries the resolved realm; pre-init each configured
+        // realm plus "unknown" (a provider without a realm resolves to "unknown").
+        // Best-effort: a provider whose issued realm differs from its filter
+        // realm (get_realm) only gets its success series created at first
+        // success. Failure series above are exact, which is what alerts watch.
+        let mut realms: BTreeSet<&str> = BTreeSet::new();
+        realms.insert("unknown");
+        for (_, _, realm) in providers.iter().chain(augmenters) {
+            realms.insert(realm.as_str());
+        }
+        for realm in realms {
+            self.auth_requests_total
+                .with_label_values(&["success", realm]);
+            self.auth_duration_seconds
+                .with_label_values(&["success", realm]);
+        }
     }
 }
 
@@ -219,5 +315,82 @@ impl MetricsRecorder for Metrics {
         self.augmenter_duration_seconds
             .with_label_values(&[augmenter_type, realm])
             .observe(duration_secs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_is_fallible_and_succeeds() {
+        let metrics = Metrics::new();
+        assert!(metrics.render().is_ok());
+    }
+
+    #[test]
+    fn build_info_is_exposed_with_crate_version() {
+        let metrics = Metrics::new();
+        let output = metrics.render().expect("render ok");
+        assert!(
+            output.contains(&format!(
+                "authotron_build_info{{version=\"{}\"}} 1",
+                env!("CARGO_PKG_VERSION")
+            )),
+            "build_info should carry the crate version:\n{output}"
+        );
+    }
+
+    #[test]
+    fn preinit_series_creates_zero_baseline_for_reachable_labels() {
+        let metrics = Metrics::new();
+        let providers = vec![(
+            "plain1".to_string(),
+            "plain".to_string(),
+            "realm1".to_string(),
+        )];
+        let augmenters = vec![(
+            "aug1".to_string(),
+            "plain".to_string(),
+            "realm1".to_string(),
+        )];
+        metrics.preinit_series(&providers, &augmenters);
+
+        let output = metrics.render().expect("render ok");
+        for series in [
+            // provider error/timeout pre-initialised at zero
+            r#"auth_provider_attempts_total{provider_name="plain1",provider_type="plain",realm="realm1",result="error"} 0"#,
+            r#"auth_provider_attempts_total{provider_name="plain1",provider_type="plain",realm="realm1",result="timeout"} 0"#,
+            // augmenter error pre-initialised at zero
+            r#"augmenter_attempts_total{augmenter_name="aug1",augmenter_type="plain",realm="realm1",result="error"} 0"#,
+            // auth failure recorded only with realm="unknown"
+            r#"auth_requests_total{realm="unknown",result="all_failed"} 0"#,
+            // auth success with the configured realm
+            r#"auth_requests_total{realm="realm1",result="success"} 0"#,
+        ] {
+            assert!(
+                output.contains(series),
+                "expected pre-initialised series: {series}\n{output}"
+            );
+        }
+    }
+
+    #[test]
+    fn preinit_does_not_create_failure_series_for_configured_realms() {
+        // Failures only ever carry realm="unknown"; pre-init must not invent
+        // e.g. all_failed for a configured realm.
+        let metrics = Metrics::new();
+        let providers = vec![(
+            "plain1".to_string(),
+            "plain".to_string(),
+            "realm1".to_string(),
+        )];
+        metrics.preinit_series(&providers, &[]);
+
+        let output = metrics.render().expect("render ok");
+        assert!(
+            !output.contains(r#"auth_requests_total{realm="realm1",result="all_failed"}"#),
+            "must not pre-init failure×configured-realm combos:\n{output}"
+        );
     }
 }

--- a/authotron/src/metrics/recorder.rs
+++ b/authotron/src/metrics/recorder.rs
@@ -102,7 +102,14 @@ impl Metrics {
         #[cfg(target_os = "linux")]
         {
             let collector = prometheus::process_collector::ProcessCollector::for_self();
-            let _ = registry.register(Box::new(collector));
+            if let Err(e) = registry.register(Box::new(collector)) {
+                tracing::warn!(
+                    event_name = "metrics.process_collector.registration_failed",
+                    event_domain = "metrics",
+                    error = %e,
+                    "failed to register process metrics collector; process metrics will be absent"
+                );
+            }
         }
 
         // Authentication metrics

--- a/authotron/src/routes/metrics.rs
+++ b/authotron/src/routes/metrics.rs
@@ -22,11 +22,25 @@ pub fn routes() -> Router<AppState> {
 /// This endpoint should be restricted via Ingress to prevent public access
 /// when/if auth-o-tron is exposed through an ingress
 async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
-    let metrics_text = state.metrics.render();
-
-    (
-        StatusCode::OK,
-        [("Content-Type", "text/plain; version=0.0.4; charset=utf-8")],
-        metrics_text,
-    )
+    match state.metrics.render() {
+        Ok(body) => (
+            StatusCode::OK,
+            [("Content-Type", "text/plain; version=0.0.4; charset=utf-8")],
+            body,
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!(
+                event_name = "metrics.render.failed",
+                event_domain = "metrics",
+                error = %e,
+                "failed to encode metrics for scrape"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to render metrics\n",
+            )
+                .into_response()
+        }
+    }
 }

--- a/authotron/src/startup.rs
+++ b/authotron/src/startup.rs
@@ -40,6 +40,32 @@ pub async fn build_app(
 
     let metrics = Metrics::new();
 
+    // Pre-initialise per-provider/augmenter/realm series at zero from the
+    // configured set so alert rules evaluate against existing series.
+    let provider_desc: Vec<(String, String, String)> = auth
+        .providers
+        .iter()
+        .map(|p| {
+            (
+                p.get_name().to_string(),
+                p.get_type().to_string(),
+                p.get_realm().unwrap_or("unknown").to_string(),
+            )
+        })
+        .collect();
+    let augmenter_desc: Vec<(String, String, String)> = auth
+        .augmenters
+        .iter()
+        .map(|a| {
+            (
+                a.get_name().to_string(),
+                a.get_type().to_string(),
+                a.get_realm().to_string(),
+            )
+        })
+        .collect();
+    metrics.preinit_series(&provider_desc, &augmenter_desc);
+
     let state = AppState {
         config: config.clone(),
         auth,


### PR DESCRIPTION
## Summary

Non-breaking quick wins on auth-o-tron's existing Prometheus setup, plus the broken README logo fix. **No metric names change**, so existing alerts/dashboards (the live `aviso-auth-o-tron` scrape) keep working.

### Changes
- **`authotron_build_info{version}`** — constant-1 gauge carrying the crate version, for deploy annotations on dashboards. Registered on the service registry (not stored on the struct; the registry holds the registered clone).
- **`Metrics::preinit_series()`** — pre-initialises the bounded auth/provider/augmenter label series to zero at startup (from the configured providers/augmenters/realms) so `rate(auth_requests_total{result="error"}[5m]) > 0` alerts evaluate against an existing baseline instead of a missing series. Failure series are exact (`realm="unknown"`); success-realm pre-init is best-effort (documented).
- **Process metrics** (CPU / memory / open FDs) — enabled the prometheus `process` feature and registered `ProcessCollector::for_self()` on the custom registry, Linux-only (`#[cfg(target_os = "linux")]`).
- **`render()` is now fallible** — returns `Result<String, prometheus::Error>` (encode error propagated, UTF-8 via lossy), and the `/metrics` handler returns **500 + logs** on encode failure instead of `.expect()`-panicking the scrape path.
- **README**: fixed the broken logo link (`docs/` → `authotron/docs/`; verified old=404, new=200).

### Tests
4 new unit tests in `recorder.rs` (render ok, build_info exposed with version, preinit zero baseline for reachable labels, negative test that failure×configured-realm is *not* invented). 109 lib tests pass, `cargo clippy` clean, `cargo fmt` clean.

## Deliberately deferred (flagged for follow-up)
- **Metric-name prefix rename** `auth_*` → `authotron_*`: highest-value for collision-safety/selectability, but **breaks the live deployment's dashboards/alerts**, so it deserves its own change.
- **HTTP RED middleware** (axum) for the non-auth routes (`/token`, `/tokens`, `/providers`, `/health`) — additive, bigger.
- **Pre-existing `EfasApiProvider::get_realm()` inconsistency**: returns hard-coded `"efas"` while `authenticate()` stamps `config.realm` on the user. This affects **realm filtering** (X-Auth-Realm matching), not just metrics, so it's out of scope here — but worth a dedicated fix.

Reviewed by Oracle (plan + implementation).

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-66
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->