### PR TITLE
chore(release): bump authotron to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authotron"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "aide",
  "async-trait",

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authotron"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 description = "Authentication and authorization gateway for web APIs. Validates credentials from multiple providers, enriches users with roles, and issues signed JWTs."
 license = "Apache-2.0"


### PR DESCRIPTION
Bump `authotron` to 0.4.0 for release.

Substantive changes since 0.3.3 (PR #66): build_info gauge, series pre-init, process metrics, fallible `render()`, README logo fix. Non-breaking metric names (existing scrapes/alerts unaffected).

After merge, the `0.4.0` tag is pushed to trigger the release and crate-publish workflows.