### PR TITLE
chore(release): bump authotron to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authotron"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aide",
  "async-trait",

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authotron"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 description = "Authentication and authorization gateway for web APIs. Validates credentials from multiple providers, enriches users with roles, and issues signed JWTs."
 license = "Apache-2.0"


### PR DESCRIPTION
Patch bump to 0.3.4 for release. Small additive observability changes (PR #66) with unchanged metric names. After merge, the `0.3.4` tag triggers the release and crate-publish workflows.