### PR TITLE
fix(metrics): correct preinit label types + release 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authotron"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aide",
  "async-trait",

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authotron"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 description = "Authentication and authorization gateway for web APIs. Validates credentials from multiple providers, enriches users with roles, and issues signed JWTs."
 license = "Apache-2.0"

--- a/authotron/src/metrics/recorder.rs
+++ b/authotron/src/metrics/recorder.rs
@@ -213,27 +213,30 @@ impl Metrics {
         for (name, provider_type, realm) in providers {
             for result in ["success", "error", "timeout"] {
                 self.provider_attempts_total.with_label_values(&[
-                    name,
-                    provider_type,
-                    realm,
+                    name.as_str(),
+                    provider_type.as_str(),
+                    realm.as_str(),
                     result,
                 ]);
             }
-            self.provider_duration_seconds
-                .with_label_values(&[name, provider_type, realm]);
+            self.provider_duration_seconds.with_label_values(&[
+                name.as_str(),
+                provider_type.as_str(),
+                realm.as_str(),
+            ]);
         }
 
         for (name, augmenter_type, realm) in augmenters {
             for result in ["success", "error"] {
                 self.augmenter_attempts_total.with_label_values(&[
-                    name,
-                    augmenter_type,
-                    realm,
+                    name.as_str(),
+                    augmenter_type.as_str(),
+                    realm.as_str(),
                     result,
                 ]);
             }
             self.augmenter_duration_seconds
-                .with_label_values(&[augmenter_type, realm]);
+                .with_label_values(&[augmenter_type.as_str(), realm.as_str()]);
         }
 
         // Pre-resolution auth failures are only ever recorded with realm="unknown".


### PR DESCRIPTION
## Why

The **0.3.4 Release (Docker image) build failed** on Linux with `E0308: mismatched types` in `Metrics::preinit_series`, so **no 0.3.4 image was produced** (the crate was published `--no-verify`, so crates.io has a non-compiling 0.3.4 — it will be yanked).

## Root cause

The 4-arg `with_label_values(&[name, provider_type, realm, result])` calls mixed `&String` (from the `(String, String, String)` descriptor tuples) and `&str` (the `result` literal). prometheus 0.14's generic `with_label_values` resolves this array element type inconsistently across targets: it **type-checks on macOS but fails on Linux** (`expected &[&String], found &[&str; N]`). My local macOS build and `cargo test` passed, which is why it slipped through; CI's `build-and-test` and the crate publish (`--no-verify`) didn't catch it, only the Docker image build did.

## Fix

Normalise every label value to `&str` via `.as_str()` so the array element type is unambiguous on all targets.

**Verified with a real Linux Docker build** (`docker build --target builder`) — `cargo build --release -p authotron` now finishes cleanly on Linux. Also macOS build + 14 metrics tests pass.

## Release

Bumps `authotron` to **0.3.5** (hotfix for the failed 0.3.4 image). After merge, the `0.3.5` tag triggers the release + crate-publish workflows, producing a working 0.3.5 image. The broken 0.3.4 crate will be yanked from crates.io.

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-69
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->