### PR TITLE
ci: add release-build job matching the Docker toolchain (rust:1.90)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,3 +29,25 @@ jobs:
         run: |
           unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy ALL_PROXY all_proxy
           cargo test -- --test-threads=1
+
+  # Compile with the SAME toolchain and profile the release image uses
+  # (Dockerfile pins rust:1.90), so a compiler-version- or release-specific
+  # error fails the PR instead of the release pipeline. The 0.3.4 image build
+  # failed on an E0308 that debug `cargo test` on newer stable Rust did not
+  # surface (older rustc resolves a mixed &String/&str array differently).
+  # Keep the container tag in sync with the Dockerfile's rust:<version>.
+  release-build:
+    runs-on: ubuntu-latest
+    container: rust:1.90-slim-bookworm
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install build tools (match Dockerfile)
+        run: apt-get update && apt-get install -y libssl-dev pkg-config build-essential && rm -rf /var/lib/apt/lists/*
+
+      - name: Cache Cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Release build (matches the Docker release image)
+        run: cargo build --release -p authotron


### PR DESCRIPTION
## Why

The **0.3.4 image build failed** on `E0308: mismatched types` in `Metrics::preinit_series` — but `build-and-test` had passed. Root cause: a **Rust-version inference gap**. `build-and-test` runs `cargo test` on **newer stable Rust**, which resolves a mixed `&String`/`&str` array fine; the release Docker image pins **`rust:1.90`**, whose older inference rejects it. So a release-only / older-rustc compile error reached the release pipeline instead of failing the PR.

## What

Adds a `release-build` job that compiles `-p authotron` in **release mode** inside the **same `rust:1.90-slim-bookworm` container** the Dockerfile uses (with the same apt deps), so this class of failure is caught on every push.

This is intentionally faithful to the release build (same toolchain version + profile + crate), not just "another build". A comment notes to keep the container tag in sync with the Dockerfile's `rust:<version>`.

The job's own run on this branch (which already includes the 0.3.5 fix) should pass — confirming both the guard and that the fix compiles on rust:1.90.

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-70
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->