### PR TITLE
feat(metrics): add HTTP-layer RED metrics (0.3.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authotron"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aide",
  "async-trait",

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authotron"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 description = "Authentication and authorization gateway for web APIs. Validates credentials from multiple providers, enriches users with roles, and issues signed JWTs."
 license = "Apache-2.0"

--- a/authotron/src/lib.rs
+++ b/authotron/src/lib.rs
@@ -18,6 +18,7 @@ pub mod augmenters;
 pub mod auth;
 pub mod config;
 pub mod metrics;
+pub mod middleware;
 pub mod models;
 pub mod providers;
 pub mod routes;

--- a/authotron/src/metrics/recorder.rs
+++ b/authotron/src/metrics/recorder.rs
@@ -8,10 +8,11 @@
 
 //! Metrics recording implementation using Prometheus.
 
+use prometheus::IntCounterVec;
 use prometheus::{
-    CounterVec, Encoder, HistogramVec, Opts, Registry, TextEncoder,
+    CounterVec, Encoder, HistogramVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder,
     register_counter_vec_with_registry, register_histogram_vec_with_registry,
-    register_int_gauge_vec_with_registry,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
 };
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -53,6 +54,26 @@ pub trait MetricsRecorder: Clone + Send + Sync + 'static {
 
     /// Records the duration of an augmenter execution.
     fn record_augmenter_duration(&self, augmenter_type: &str, realm: &str, duration_secs: f64);
+
+    /// Records a completed HTTP request: count by route/method/status and
+    /// duration by route/method.
+    fn record_http_request(&self, route: &str, method: &str, status_code: &str, duration_secs: f64);
+
+    /// Increments the in-flight gauge for `method` and returns a guard that
+    /// decrements it on drop, so the gauge cannot leak on cancellation.
+    fn http_in_flight_guard(&self, method: &str) -> HttpInFlightGuard;
+}
+
+/// Decrements the in-flight gauge when dropped (request completion, client
+/// disconnect, or cancellation), so the gauge cannot leak.
+pub struct HttpInFlightGuard(Option<IntGauge>);
+
+impl Drop for HttpInFlightGuard {
+    fn drop(&mut self) {
+        if let Some(gauge) = self.0.take() {
+            gauge.dec();
+        }
+    }
 }
 
 /// Prometheus metrics collector.
@@ -71,6 +92,11 @@ pub struct Metrics {
     // Augmenter metrics
     augmenter_attempts_total: CounterVec,
     augmenter_duration_seconds: HistogramVec,
+
+    // HTTP-layer metrics
+    http_requests_total: IntCounterVec,
+    http_request_duration_seconds: HistogramVec,
+    http_requests_in_flight: IntGaugeVec,
 }
 
 impl Metrics {
@@ -173,6 +199,37 @@ impl Metrics {
         )
         .expect("Failed to register augmenter_duration_seconds");
 
+        let http_requests_total = register_int_counter_vec_with_registry!(
+            Opts::new(
+                "authotron_http_requests_total",
+                "HTTP requests by matched route pattern, method, and status code. Unrouted requests collapse into route=\"unmatched\" to bound label cardinality under path scans. The label is named `route` (not `endpoint`) to avoid colliding with the Prometheus Operator target label `endpoint`."
+            ),
+            &["route", "method", "status_code"],
+            registry.clone()
+        )
+        .expect("Failed to register authotron_http_requests_total");
+
+        let http_request_duration_seconds = register_histogram_vec_with_registry!(
+            "authotron_http_request_duration_seconds",
+            "HTTP request duration in seconds by matched route pattern and method, measured until the response is produced.",
+            &["route", "method"],
+            vec![
+                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0
+            ],
+            registry.clone()
+        )
+        .expect("Failed to register authotron_http_request_duration_seconds");
+
+        let http_requests_in_flight = register_int_gauge_vec_with_registry!(
+            Opts::new(
+                "authotron_http_requests_in_flight",
+                "HTTP requests currently being processed, by method. Labelled by method only: the matched route pattern is not known until routing completes, by which point the request is already in flight."
+            ),
+            &["method"],
+            registry.clone()
+        )
+        .expect("Failed to register authotron_http_requests_in_flight");
+
         Metrics {
             registry,
             auth_requests_total,
@@ -181,6 +238,9 @@ impl Metrics {
             provider_duration_seconds,
             augmenter_attempts_total,
             augmenter_duration_seconds,
+            http_requests_total,
+            http_request_duration_seconds,
+            http_requests_in_flight,
         }
     }
 
@@ -326,6 +386,27 @@ impl MetricsRecorder for Metrics {
             .with_label_values(&[augmenter_type, realm])
             .observe(duration_secs);
     }
+
+    fn record_http_request(
+        &self,
+        route: &str,
+        method: &str,
+        status_code: &str,
+        duration_secs: f64,
+    ) {
+        self.http_requests_total
+            .with_label_values(&[route, method, status_code])
+            .inc();
+        self.http_request_duration_seconds
+            .with_label_values(&[route, method])
+            .observe(duration_secs);
+    }
+
+    fn http_in_flight_guard(&self, method: &str) -> HttpInFlightGuard {
+        let gauge = self.http_requests_in_flight.with_label_values(&[method]);
+        gauge.inc();
+        HttpInFlightGuard(Some(gauge))
+    }
 }
 
 #[cfg(test)]
@@ -383,6 +464,56 @@ mod tests {
                 "expected pre-initialised series: {series}\n{output}"
             );
         }
+    }
+
+    #[test]
+    fn http_request_records_count_and_duration() {
+        let metrics = Metrics::new();
+        metrics.record_http_request("/authenticate", "GET", "200", 0.01);
+        metrics.record_http_request("/authenticate", "GET", "200", 0.02);
+        metrics.record_http_request("/authenticate", "GET", "401", 0.01);
+
+        let output = metrics.render().expect("render ok");
+        assert!(
+            output.contains(
+                r#"authotron_http_requests_total{method="GET",route="/authenticate",status_code="200"} 2"#
+            ),
+            "expected 2 successful requests:\n{output}"
+        );
+        assert!(
+            output.contains(
+                r#"authotron_http_requests_total{method="GET",route="/authenticate",status_code="401"} 1"#
+            ),
+            "expected 1 unauthorized request:\n{output}"
+        );
+        assert!(
+            output.contains(
+                r#"authotron_http_request_duration_seconds_count{method="GET",route="/authenticate"} 3"#
+            ),
+            "expected 3 duration observations:\n{output}"
+        );
+    }
+
+    #[test]
+    fn http_in_flight_guard_rises_then_falls_on_drop() {
+        let metrics = Metrics::new();
+        {
+            let _g = metrics.http_in_flight_guard("GET");
+            assert!(
+                metrics
+                    .render()
+                    .expect("render ok")
+                    .contains(r#"authotron_http_requests_in_flight{method="GET"} 1"#),
+                "gauge should read 1 while the guard is held"
+            );
+        }
+        assert!(
+            metrics
+                .render()
+                .expect("render ok")
+                .contains(r#"authotron_http_requests_in_flight{method="GET"} 0"#),
+            "gauge should return to 0 after the guard drops"
+        );
     }
 
     #[test]

--- a/authotron/src/middleware/http_metrics.rs
+++ b/authotron/src/middleware/http_metrics.rs
@@ -1,0 +1,77 @@
+// (C) Copyright 2025- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Per-request RED metrics (`authotron_http_requests_total`,
+//! `authotron_http_request_duration_seconds`,
+//! `authotron_http_requests_in_flight`) for every route.
+//!
+//! The `route` label is the matched route pattern (from [`MatchedPath`]),
+//! never the raw request path, so cardinality stays bounded under path scans:
+//! unrouted requests collapse into `route="unmatched"`. The in-flight gauge is
+//! labelled by method only, because the route pattern is not known until
+//! routing completes, by which point the request is already in flight.
+
+use std::time::Instant;
+
+use axum::{
+    extract::{MatchedPath, State},
+    http::{Method, Request},
+    middleware::Next,
+    response::Response,
+};
+
+use crate::metrics::MetricsRecorder;
+use crate::state::AppState;
+
+/// Collapse arbitrary HTTP methods to a fixed set so the `method` label has
+/// bounded cardinality (HTTP permits arbitrary extension tokens).
+fn method_label(method: &Method) -> &'static str {
+    match method.as_str() {
+        "GET" => "GET",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "DELETE" => "DELETE",
+        "PATCH" => "PATCH",
+        "HEAD" => "HEAD",
+        "OPTIONS" => "OPTIONS",
+        "CONNECT" => "CONNECT",
+        "TRACE" => "TRACE",
+        _ => "other",
+    }
+}
+
+/// Records request count, duration, and in-flight gauge for each request.
+///
+/// The in-flight guard decrements on drop, covering the normal, error, and
+/// client-disconnect (cancellation) paths.
+pub async fn record_http_metrics(
+    State(state): State<AppState>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let method = method_label(request.method());
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|p| p.as_str().to_owned())
+        .unwrap_or_else(|| "unmatched".to_owned());
+
+    let _in_flight = state.metrics.http_in_flight_guard(method);
+    let started_at = Instant::now();
+
+    let response = next.run(request).await;
+
+    state.metrics.record_http_request(
+        &route,
+        method,
+        response.status().as_str(),
+        started_at.elapsed().as_secs_f64(),
+    );
+
+    response
+}

--- a/authotron/src/middleware/mod.rs
+++ b/authotron/src/middleware/mod.rs
@@ -1,0 +1,13 @@
+// (C) Copyright 2025- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! HTTP middleware.
+
+mod http_metrics;
+
+pub use http_metrics::record_http_metrics;

--- a/authotron/src/routes/mod.rs
+++ b/authotron/src/routes/mod.rs
@@ -20,6 +20,7 @@ mod metrics;
 mod providers;
 mod tokens;
 
+use crate::middleware::record_http_metrics;
 use crate::state::AppState;
 use axum::Router;
 
@@ -31,6 +32,10 @@ pub fn create_app_router(state: AppState) -> Router {
         .merge(providers::routes())
         .merge(augmenters::routes())
         .merge(health::routes())
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            record_http_metrics,
+        ))
         .with_state(state)
 }
 

--- a/authotron/tests/common.rs
+++ b/authotron/tests/common.rs
@@ -26,6 +26,12 @@ pub struct Claims {
 }
 
 pub async fn build_app(config: ConfigV2) -> (Router, Arc<ConfigV2>) {
+    let (app, config, _state) = build_app_with_state(config).await;
+    (app, config)
+}
+
+#[allow(dead_code)]
+pub async fn build_app_with_state(config: ConfigV2) -> (Router, Arc<ConfigV2>, AppState) {
     let config = Arc::new(config);
     let store = create_store(&config.store).await;
     let auth = Arc::new(Auth::new(
@@ -45,7 +51,7 @@ pub async fn build_app(config: ConfigV2) -> (Router, Arc<ConfigV2>) {
         metrics,
     };
 
-    (create_app_router(state), config)
+    (create_app_router(state.clone()), config, state)
 }
 
 #[allow(dead_code)]

--- a/authotron/tests/server_integration.rs
+++ b/authotron/tests/server_integration.rs
@@ -97,6 +97,54 @@ async fn homepage_returns_html_with_version() {
 }
 
 #[tokio::test]
+async fn http_metrics_record_matched_route_and_status() {
+    let config = base_config(0, false, 0);
+    let (app, _, state) = common::build_app_with_state(config).await;
+
+    let response = app
+        .oneshot(Request::get("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let output = state.metrics.render().expect("render ok");
+    assert!(
+        output.contains(
+            r#"authotron_http_requests_total{method="GET",route="/",status_code="200"} 1"#
+        ),
+        "expected the homepage request counted under its matched route:\n{output}"
+    );
+    assert!(
+        output.contains(r#"authotron_http_request_duration_seconds_count{method="GET",route="/"}"#),
+        "expected a duration observation for the matched route:\n{output}"
+    );
+    assert!(
+        output.contains(r#"authotron_http_requests_in_flight{method="GET"} 0"#),
+        "in-flight gauge must return to zero after the request completes:\n{output}"
+    );
+}
+
+#[tokio::test]
+async fn http_metrics_collapse_unrouted_requests() {
+    let config = base_config(0, false, 0);
+    let (app, _, state) = common::build_app_with_state(config).await;
+
+    let response = app
+        .oneshot(Request::get("/does-not-exist").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let output = state.metrics.render().expect("render ok");
+    assert!(
+        output.contains(
+            r#"authotron_http_requests_total{method="GET",route="unmatched",status_code="404"} 1"#
+        ),
+        "unrouted requests must collapse into route=\"unmatched\":\n{output}"
+    );
+}
+
+#[tokio::test]
 async fn logo_returns_png() {
     let config = base_config(0, false, 0);
     let (app, _) = common::build_app(config).await;


### PR DESCRIPTION
## Summary

auth-o-tron only measured auth at the **domain layer** (`auth_requests_total{result}` = success/all_failed/invalid_header/no_auth_header). There were no transport-layer metrics, so HTTP faults — 5xx panics, unexpected 404s, in-flight pileups — were invisible. aviso-server has both; this brings auth-o-tron to parity.

## What this adds

An Axum middleware (`from_fn_with_state`) that records, for every request on the **app router**:

- `authotron_http_requests_total{route,method,status_code}`
- `authotron_http_request_duration_seconds{route,method}`
- `authotron_http_requests_in_flight{method}`

### Design notes
- **`route` is the matched route pattern** (`MatchedPath`), never the raw path, so cardinality stays bounded under path scans — unrouted requests collapse into `route="unmatched"`.
- **In-flight gauge uses a `Drop` guard**, so it decrements on the normal, error, and client-disconnect (cancellation) paths and cannot leak.
- **Method label is collapsed** to a fixed set (arbitrary HTTP extension tokens → `other`) to bound cardinality.
- Layered on the **app router only** — `/metrics` scrapes don't count themselves.

## Why distinct from the existing auth metrics
The domain `auth_*` metrics tell you *why* an attempt failed (bad credentials → 401). The new HTTP metrics catch faults the domain layer can't see: a **5xx spike means the service itself is failing** (panic, render error), which is invisible in `auth_requests_total`.

## Tests
- Unit: record count+duration, in-flight guard rise/fall on drop.
- Integration (real Axum stack): matched route + status code, unrouted → `route="unmatched"` 404.
- **120 tests pass, clippy clean.**

Bumps the crate to **0.3.6** (Cargo.toml + Cargo.lock).

The companion dashboard API (RED) row lives in `auth-o-tron-chart` (`feat/dashboard`).

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-71
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->