### PR TITLE
fix(client): coalesce concurrent auth cache fills (single-flight)

### DIFF
--- a/authotron-client/src/lib.rs
+++ b/authotron-client/src/lib.rs
@@ -170,28 +170,17 @@ impl AuthClient {
     pub async fn authenticate(&self, auth_header: &str) -> Result<User, AuthError> {
         let converted = convert_email_key(auth_header);
 
-        // Single-flight cache fill. When many requests carrying the *same*
-        // credential arrive concurrently against a cold cache, moka runs the
-        // loader exactly once and every caller awaits that single result. This
-        // collapses what would otherwise be a thundering herd of identical
-        // `/authenticate` calls (one per request) into one upstream call per
-        // key. Without it, a burst of N requests stampedes the auth provider on
-        // a cold cache, exhausting it past the auth timeout and yielding 503s.
-        //
-        // Successful results are cached for the TTL. Errors are deliberately
-        // not cached (no negative caching / poisoning), but the concurrent
-        // batch still shares the single in-flight attempt, so even a failing
-        // burst makes only one upstream call.
+        // Single-flight fill: moka runs the loader once per key, so concurrent
+        // misses for the same credential share one upstream call instead of
+        // stampeding the provider. Errors are not cached (no negative caching).
         self.cache
             .try_get_with(converted.clone(), self.fetch_user(converted))
             .await
             .map_err(|err| (*err).clone())
     }
 
-    /// Call auth-o-tron's `/authenticate` endpoint and decode the returned JWT.
-    ///
-    /// This is the cache loader for [`Self::authenticate`]; moka guarantees it
-    /// runs at most once per key across concurrently-waiting callers.
+    /// Cache loader for [`Self::authenticate`]: calls `/authenticate` and
+    /// decodes the JWT. moka runs it at most once per key across concurrent callers.
     async fn fetch_user(&self, converted: String) -> Result<User, AuthError> {
         let response = self
             .http

--- a/authotron-client/src/lib.rs
+++ b/authotron-client/src/lib.rs
@@ -170,10 +170,29 @@ impl AuthClient {
     pub async fn authenticate(&self, auth_header: &str) -> Result<User, AuthError> {
         let converted = convert_email_key(auth_header);
 
-        if let Some(user) = self.cache.get(&converted).await {
-            return Ok(user);
-        }
+        // Single-flight cache fill. When many requests carrying the *same*
+        // credential arrive concurrently against a cold cache, moka runs the
+        // loader exactly once and every caller awaits that single result. This
+        // collapses what would otherwise be a thundering herd of identical
+        // `/authenticate` calls (one per request) into one upstream call per
+        // key. Without it, a burst of N requests stampedes the auth provider on
+        // a cold cache, exhausting it past the auth timeout and yielding 503s.
+        //
+        // Successful results are cached for the TTL. Errors are deliberately
+        // not cached (no negative caching / poisoning), but the concurrent
+        // batch still shares the single in-flight attempt, so even a failing
+        // burst makes only one upstream call.
+        self.cache
+            .try_get_with(converted.clone(), self.fetch_user(converted))
+            .await
+            .map_err(|err| (*err).clone())
+    }
 
+    /// Call auth-o-tron's `/authenticate` endpoint and decode the returned JWT.
+    ///
+    /// This is the cache loader for [`Self::authenticate`]; moka guarantees it
+    /// runs at most once per key across concurrently-waiting callers.
+    async fn fetch_user(&self, converted: String) -> Result<User, AuthError> {
         let response = self
             .http
             .get(format!("{}/authenticate", self.url.trim_end_matches('/')))
@@ -218,11 +237,7 @@ impl AuthClient {
                 message: "Authorization header is not Bearer scheme".to_string(),
             })?;
 
-        let user = decode_jwt(jwt_token, &self.secret)?;
-
-        self.cache.insert(converted, user.clone()).await;
-
-        Ok(user)
+        decode_jwt(jwt_token, &self.secret)
     }
 }
 
@@ -507,6 +522,48 @@ mod tests {
         assert_eq!(user.realm, "testrealm");
         assert!(user.roles.contains(&"admin".to_string()));
         assert!(user.roles.contains(&"default".to_string()));
+    }
+
+    /// A burst of concurrent authentications for the same cold credential must
+    /// collapse into a SINGLE upstream `/authenticate` call (single-flight),
+    /// not one call per request. `expect(1)` fails if the herd is not coalesced.
+    #[tokio::test]
+    async fn test_concurrent_auth_is_single_flight() {
+        let mut server = mockito::Server::new_async().await;
+        let jwt = make_test_jwt("testsecret");
+
+        let mock = server
+            .mock("GET", "/authenticate")
+            .with_status(200)
+            .with_header("Authorization", &format!("Bearer {}", jwt))
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = AuthClient::new(
+            &server.url(),
+            b"testsecret",
+            Duration::from_secs(5),
+            None,
+            None,
+        );
+
+        // Fire many concurrent authentications for the SAME (cold) credential.
+        const N: usize = 64;
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let client = client.clone();
+            handles.push(tokio::spawn(async move {
+                client.authenticate("Bearer sometoken").await
+            }));
+        }
+        for h in handles {
+            let user = h.await.unwrap().expect("auth should succeed");
+            assert_eq!(user.username, "testuser");
+        }
+
+        // Coalesced: the whole herd produced exactly one upstream call.
+        mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/authotron/src/providers/ecmwfapi_provider.rs
+++ b/authotron/src/providers/ecmwfapi_provider.rs
@@ -7,6 +7,7 @@
 // does it submit to any jurisdiction.
 
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -21,6 +22,11 @@ use cached::Return;
 use cached::proc_macro::cached;
 use reqwest;
 const CACHE_HIT_LOG_WINDOW: Duration = Duration::from_secs(30);
+
+/// Shared client for who-am-i calls. Reusing one client (and its connection
+/// pool) avoids a fresh TCP+TLS handshake on every cache-miss, which under load
+/// churned connections and amplified pressure on the upstream ECMWF API.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
 /// The config needed for the ECMWF API provider (who-am-i endpoint).
 #[derive(Deserialize, Serialize, Debug, JsonSchema, Clone)]
@@ -102,7 +108,6 @@ impl Provider for EcmwfApiProvider {
     )
 )]
 async fn query(uri: String, token: String, realm: String) -> Result<Return<User>, String> {
-    let client = reqwest::Client::new();
     let url = format!("{}/who-am-i?token={}", uri, token);
 
     debug!(
@@ -112,7 +117,7 @@ async fn query(uri: String, token: String, realm: String) -> Result<Return<User>
         realm = realm.as_str(),
         "sending ECMWF who-am-i request"
     );
-    let response = match client.get(&url).send().await {
+    let response = match HTTP_CLIENT.get(&url).send().await {
         Ok(r) => r,
         Err(e) => return Err(format!("Error sending request: {}", e)),
     };


### PR DESCRIPTION
## Problem

`AuthClient::authenticate` checks the TTL cache and, on a miss, calls the upstream `/authenticate` endpoint and then inserts the result — a classic **get-then-insert** pattern with an unguarded gap between the miss and the fill.

On a **cold cache**, a burst of *N* concurrent requests carrying the **same** credential all see a miss and each issues its own upstream call. This is a thundering herd: instead of one validation per credential, the auth provider gets *N* simultaneous identical validations.

We hit this in a load test of a Polytope frontend (which embeds this client): ~512 concurrent requests under one admin credential against a freshly-deployed (cold-cache) frontend produced **451 rejections** in a ~5 s window, all `auth.provider.all_failed` → `Provider 'ECMWF API Provider' timed out` → HTTP **503 "auth service unavailable"**. Only the handful of requests whose validation happened to land got through.

## Fix

Replace the manual `get`/`insert` with moka's **`try_get_with`** single-flight loader. moka guarantees the loader runs **at most once per key** across concurrently-waiting callers: the first caller runs the upstream call, the rest await that single result. So *N* concurrent misses for the same key collapse into **one** upstream call (one per key, per node).

Semantics preserved:
- Successful results are cached for the TTL (unchanged).
- Errors are **not** cached (no negative-caching / poisoning), but the in-flight batch still shares the single attempt — so even a failing burst makes one upstream call, and the next request retries cleanly.
- `AuthError: Clone`, so the `Arc<AuthError>` returned to waiters is unwrapped back to `AuthError`.

## Test

Adds `test_concurrent_auth_is_single_flight`: fires 64 concurrent `authenticate()` calls for the same cold credential against a mockito server with `.expect(1)`, asserting exactly **one** upstream call. (Fails on the old get-then-insert path.)

All existing tests pass; `cargo fmt`/`clippy` clean.

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-72
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->