### PR TITLE
perf(provider): reuse a shared HTTP client for DESP IAM calls

### DIFF
--- a/authotron/src/providers/jwt_provider.rs
+++ b/authotron/src/providers/jwt_provider.rs
@@ -15,12 +15,18 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::{debug, info};
 
 use crate::utils::log_throttle::should_emit;
 use crate::{models::user::User, providers::Provider, utils::value::value_to_string};
 const CACHE_HIT_LOG_WINDOW: Duration = Duration::from_secs(30);
+
+/// Shared client for JWKS fetches. Reusing one client (and its connection pool)
+/// avoids a fresh TCP+TLS handshake on every cache-miss, which under load churned
+/// connections and amplified pressure on the upstream identity provider.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
 /// JWT config structure for external usage
 #[derive(Deserialize, Serialize, JsonSchema, Debug, Clone)]
@@ -226,7 +232,9 @@ pub async fn get_certs(cert_uri: String) -> Result<Return<String>, String> {
         cert_uri = cert_uri.as_str(),
         "fetching JWK set from certificate URI"
     );
-    let res = reqwest::get(&cert_uri)
+    let res = HTTP_CLIENT
+        .get(&cert_uri)
+        .send()
         .await
         .map_err(|e| format!("Failed to download certificates: {}", e))?;
 

--- a/authotron/src/providers/openid_offline_provider.rs
+++ b/authotron/src/providers/openid_offline_provider.rs
@@ -12,6 +12,7 @@ use cached::proc_macro::cached;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::{debug, info};
 
@@ -20,6 +21,12 @@ use crate::models::user::User;
 use crate::providers::Provider;
 use crate::utils::log_throttle::should_emit;
 const CACHE_HIT_LOG_WINDOW: Duration = Duration::from_secs(30);
+
+/// Shared client for DESP IAM calls (offline-token introspection and refresh
+/// exchange). Reusing one client (and its connection pool) avoids a fresh
+/// TCP+TLS handshake on every cache-miss, which under load churned connections
+/// and amplified pressure on the upstream DESP identity provider.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
 /// Config for an OpenID provider that also supports offline tokens.
 #[derive(Deserialize, Debug, Serialize, JsonSchema, Hash, Clone, PartialEq, Eq)]
@@ -91,9 +98,7 @@ async fn check_offline_access_token(
         "{}/realms/{}/protocol/openid-connect/token/introspect",
         config.iam_url, config.realm
     );
-    let client = reqwest::Client::new();
-
-    let resp = client
+    let resp = HTTP_CLIENT
         .post(&introspection_url)
         .basic_auth(config.private_client_id, Some(config.private_client_secret))
         .form(&[("token", token)])
@@ -142,8 +147,7 @@ async fn get_access_token(
         config.iam_url, config.realm
     );
 
-    let client = reqwest::Client::new();
-    let resp = client
+    let resp = HTTP_CLIENT
         .post(&token_endpoint)
         .basic_auth(config.private_client_id, Some(config.private_client_secret))
         .form(&refresh_data)


### PR DESCRIPTION
## What

Mirror the ECMWF who-am-i fix (8b0ce89 — shared `HTTP_CLIENT` reuse) on the two DestinE (DESP) providers.

- **openid_offline_provider**: built a fresh `reqwest::Client::new()` on *both* the offline-token introspection call and the refresh/token-exchange call.
- **jwt_provider**: used `reqwest::get()` (a fresh client) per JWKS fetch.

Both now route upstream calls through a shared `static HTTP_CLIENT: LazyLock<reqwest::Client>`, reusing the connection pool.

## Why

On a cold cache, a burst of DESP authentications each opened a new TCP+TLS handshake per cache-miss, churning connections and amplifying pressure on the DESP identity provider (`auth.destine.eu`) — the same cache-storm pattern already fixed for the ECMWF API path in 8b0ce89.

The *thundering-herd* half (concurrent misses collapsing into a single upstream call) is already handled here by the `cached(sync_writes = "default")` layer, so this PR closes the remaining connection-churn gap for the DESP providers specifically.

## Test

- `cargo check -p authotron` clean.
- `cargo test -p authotron --lib` — all 111 lib tests pass, including the openid-offline introspection/exchange and jwt JWKS tests (which exercise the shared client against mockito).

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-73
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->