### PR TITLE
feat: add /whoami endpoint and stop exposing the raw ECMWF API key

### DIFF
--- a/authotron/docs/src/api/endpoints.md
+++ b/authotron/docs/src/api/endpoints.md
@@ -22,6 +22,36 @@ curl -H "Authorization: Basic $(echo -n 'user:pass' | base64)" \
   http://localhost:8080/authenticate
 ```
 
+### GET /whoami
+
+Returns the authenticated user's identity as JSON. The response reflects the same identity (after provider validation and augmenter enrichment) that would be embedded in a JWT issued by `/authenticate`, so callers can inspect their effective identity without decoding a JWT.
+
+| Aspect | Details |
+|--------|---------|
+| **Request headers** | `Authorization: Basic <base64>` or `Authorization: Bearer <token>`. Optional: `X-Auth-Realm: <realm>` |
+| **Success (200)** | JSON body with the authenticated user |
+| **Failure (401)** | `WWW-Authenticate` challenge header listing available schemes |
+
+**Example:**
+
+```bash
+curl -H "Authorization: Basic $(echo -n 'user:pass' | base64)" \
+  http://localhost:8080/whoami
+```
+
+**Response:**
+
+```json
+{
+  "version": 1,
+  "username": "user",
+  "realm": "localrealm",
+  "roles": ["admin"],
+  "attributes": {},
+  "scopes": {}
+}
+```
+
 ### GET /token
 
 Creates an opaque token for the authenticated user. Requires the token store to be enabled.
@@ -122,6 +152,7 @@ auth_duration_seconds_bucket{result="success",realm="internal",le="0.1"} 35
 | Method | Path | Port | Auth | Purpose |
 |--------|------|------|------|---------|
 | GET | /authenticate | 8080 | Credentials | Main auth, returns JWT |
+| GET | /whoami | 8080 | Credentials | Authenticated identity as JSON |
 | GET | /token | 8080 | JWT | Create opaque token |
 | GET | /tokens | 8080 | JWT | List tokens |
 | DELETE | /token/{token} | 8080 | JWT | Delete token |

--- a/authotron/src/providers/ecmwfapi_provider.rs
+++ b/authotron/src/providers/ecmwfapi_provider.rs
@@ -132,11 +132,14 @@ async fn query(uri: String, token: String, realm: String) -> Result<Return<User>
 
         let username = user_info["uid"].as_str().unwrap_or_default().to_string();
         let email = user_info["email"].as_str().map(|s| s.to_string());
+        // The raw API key must not be stored as a user attribute: attributes
+        // propagate into JWT claims, the token store, and identity responses,
+        // which would expose the long-lived credential to anyone who can read
+        // an issued JWT.
         let mut attributes = HashMap::new();
         if let Some(email) = email {
             attributes.insert("ecmwf-email".to_string(), email);
         }
-        attributes.insert("ecmwf-apikey".to_string(), token.clone());
         Ok(Return::new(User::new(
             realm,
             username,
@@ -186,6 +189,10 @@ mod tests {
         let user = result.unwrap();
         assert_eq!(user.username, "user_ecmwf");
         assert_eq!(user.realm, realm);
+        assert!(
+            user.attributes.values().all(|v| !v.contains(token)),
+            "the raw API key must not appear in user attributes"
+        );
     }
 
     /// Test that an invalid token (simulated with a 403 response) returns an error.

--- a/authotron/src/providers/ecmwfapi_provider.rs
+++ b/authotron/src/providers/ecmwfapi_provider.rs
@@ -190,8 +190,12 @@ mod tests {
         assert_eq!(user.username, "user_ecmwf");
         assert_eq!(user.realm, realm);
         assert!(
+            !user.attributes.contains_key("ecmwf-apikey"),
+            "the ecmwf-apikey attribute must not be present"
+        );
+        assert!(
             user.attributes.values().all(|v| !v.contains(token)),
-            "the raw API key must not appear in user attributes"
+            "the raw API key must not appear in any attribute value"
         );
     }
 

--- a/authotron/src/routes/mod.rs
+++ b/authotron/src/routes/mod.rs
@@ -19,6 +19,7 @@ mod homepage;
 mod metrics;
 mod providers;
 mod tokens;
+mod whoami;
 
 use crate::middleware::record_http_metrics;
 use crate::state::AppState;
@@ -28,6 +29,7 @@ pub fn create_app_router(state: AppState) -> Router {
     Router::new()
         .merge(homepage::routes())
         .merge(auth::routes())
+        .merge(whoami::routes())
         .merge(tokens::routes())
         .merge(providers::routes())
         .merge(augmenters::routes())

--- a/authotron/src/routes/whoami.rs
+++ b/authotron/src/routes/whoami.rs
@@ -8,7 +8,7 @@
 
 //! Authenticated identity introspection endpoint.
 
-use axum::{Json, Router, routing::get};
+use axum::{Json, Router, http::header, response::IntoResponse, routing::get};
 
 use crate::models::user::User;
 use crate::state::AppState;
@@ -25,6 +25,9 @@ pub fn routes() -> Router<AppState> {
 /// (username, realm, roles, attributes, scopes) that would be embedded in
 /// a JWT issued by `/authenticate`. This lets callers inspect their
 /// effective identity without decoding a JWT.
-async fn whoami(user: User) -> Json<User> {
-    Json(user)
+///
+/// The response carries `Cache-Control: no-store` so identity data is never
+/// retained by browser or intermediary caches.
+async fn whoami(user: User) -> impl IntoResponse {
+    ([(header::CACHE_CONTROL, "no-store")], Json(user))
 }

--- a/authotron/src/routes/whoami.rs
+++ b/authotron/src/routes/whoami.rs
@@ -1,0 +1,30 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Authenticated identity introspection endpoint.
+
+use axum::{Json, Router, routing::get};
+
+use crate::models::user::User;
+use crate::state::AppState;
+
+/// Registers identity introspection routes.
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/whoami", get(whoami))
+}
+
+/// Returns the authenticated user's identity as JSON.
+///
+/// The user is extracted from the request via configured authentication
+/// providers and augmenters, so the response reflects the same identity
+/// (username, realm, roles, attributes, scopes) that would be embedded in
+/// a JWT issued by `/authenticate`. This lets callers inspect their
+/// effective identity without decoding a JWT.
+async fn whoami(user: User) -> Json<User> {
+    Json(user)
+}

--- a/authotron/tests/offline_integration.rs
+++ b/authotron/tests/offline_integration.rs
@@ -112,6 +112,48 @@ async fn integration_plain_auth_flow() {
 }
 
 #[tokio::test]
+async fn integration_whoami_returns_identity() {
+    let (app, _config) = build_app(load_test_config()).await;
+
+    let response = app
+        .clone()
+        .oneshot(request_with_basic("/whoami", "adam:admin", Method::GET))
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body should be readable");
+    let user: serde_json::Value = serde_json::from_slice(&body).expect("body should be valid JSON");
+
+    assert_eq!(user["username"], "adam");
+    assert_eq!(user["realm"], "ecmwf");
+    let roles = user["roles"].as_array().expect("roles should be an array");
+    assert_eq!(roles.len(), 2);
+    assert!(roles.iter().any(|r| r == "user"));
+    assert!(roles.iter().any(|r| r == "admin"));
+}
+
+#[tokio::test]
+async fn integration_whoami_requires_authentication() {
+    let (app, _config) = build_app(load_test_config()).await;
+
+    let response = app
+        .clone()
+        .oneshot(request_with_basic(
+            "/whoami",
+            "adam:wrongpassword",
+            Method::GET,
+        ))
+        .await
+        .expect("request should complete");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
 async fn integration_plain_auth_failure() {
     let (app, _config) = build_app(load_test_config()).await;
 

--- a/authotron/tests/offline_integration.rs
+++ b/authotron/tests/offline_integration.rs
@@ -122,6 +122,15 @@ async fn integration_whoami_returns_identity() {
         .expect("request should succeed");
 
     assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("cache-control")
+            .expect("Cache-Control header missing")
+            .to_str()
+            .expect("Cache-Control header not valid UTF-8"),
+        "no-store"
+    );
 
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await

--- a/authotron/tests/offline_integration.rs
+++ b/authotron/tests/offline_integration.rs
@@ -139,10 +139,18 @@ async fn integration_whoami_returns_identity() {
 
     assert_eq!(user["username"], "adam");
     assert_eq!(user["realm"], "ecmwf");
-    let roles = user["roles"].as_array().expect("roles should be an array");
-    assert_eq!(roles.len(), 2);
-    assert!(roles.iter().any(|r| r == "user"));
-    assert!(roles.iter().any(|r| r == "admin"));
+    let mut roles: Vec<&str> = user["roles"]
+        .as_array()
+        .expect("roles should be an array")
+        .iter()
+        .map(|r| r.as_str().expect("roles should be strings"))
+        .collect();
+    roles.sort_unstable();
+    assert_eq!(
+        roles,
+        ["admin", "user"],
+        "expected the exact role set granted by the provider and augmenter"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Two related changes around identity visibility and credential exposure:

1. **New `GET /whoami` endpoint** — returns the authenticated user's identity as JSON
2. **Security fix** — the ECMWF API provider no longer stores the raw API key as a user attribute

## Motivation

There was previously no way to inspect your effective identity (roles, attributes, realm) as structured data without decoding JWT claims — coupling consumers to an internal token format. Adding introspection surfaced a pre-existing issue: the ECMWF API provider embedded the caller's raw API key in `User.attributes`, which propagated into:

- **JWT claims** — forwarded by the ingress to all backend services; JWTs are base64-readable, so anyone who saw a token (logs, traces, devtools) could extract the long-lived credential. This also broke the lifetime guarantee of short-lived JWTs: an expired JWT still yielded a valid API key.
- **The token store** — persisted in plaintext alongside opaque tokens.
- **`/whoami` responses** — echoed back to the caller.

Removing the attribute at the provider level fixes all three sinks at once (same approach as the earlier EFAS fix, `"fix: keep only email from EFAS attributes"`). `ecmwf-email` is retained.

## Changes

- `GET /whoami` — authenticates via the standard `User` extractor (providers + augmenters), returns the canonical identity JSON. Mirrors OIDC `/userinfo` / `kubectl auth whoami` style self-introspection. 401 with `WWW-Authenticate` challenges on failure.
- `ecmwfapi_provider`: drop `ecmwf-apikey` from user attributes, with an invariant comment explaining why it must not return, plus a regression assertion in the provider unit test.
- Docs: `/whoami` section and endpoint summary row in `api/endpoints.md`.

## Testing

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all pass (150 tests)
- New integration tests: `/whoami` returns identity with provider + augmenter roles; rejects bad credentials with 401
- New regression assertion: raw API key must not appear in ECMWF user attributes
- Manually verified against a live instance with Basic auth, JWT round-trip, and ECMWF API key

## Notes for reviewers

- **Potential breaking change**: if any downstream service reads `ecmwf-apikey` from JWT claims (it was added deliberately in 0a4c57d), it will stop finding it. Please flag if you know of a consumer — the replacement pattern should be a dedicated token exchange, not credentials-in-claims.
- JWTs issued before deployment still contain API keys until they expire (config `exp`, typically 1h).


<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-74
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->
