### PR TITLE
chore(deps): update openssl to 0.10.81 and rand 0.8 to 0.8.6 for residual advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2118,7 +2118,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2171,15 +2171,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2588,9 +2587,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",


### PR DESCRIPTION
## Summary

Follow-up to #75/#76 clearing the remaining open Dependabot alerts (the original alert table truncated the openssl list with "View 3 more"):

| Dependency | From | To | Advisories | Pulled in by |
|---|---|---|---|---|
| openssl | 0.10.78 | 0.10.81 | GHSA-phqj-4mhp-q6mq (needs ≥0.10.80), GHSA-xv59-967r-8726, GHSA-xp3w-r5p5-63rr (need ≥0.10.79) | ldap3 → native-tls |
| rand (0.8 series) | 0.8.5 | 0.8.6 | GHSA-cq8v-f236-94qc (also covers `>= 0.7.0, < 0.8.6`) | jsonwebtoken / rsa |

Lockfile-only; MSRV-safe (openssl 0.10.81 declares 1.80, rand 0.8.6 declares none — both within rust-version 1.88).

After this, `gh api .../dependabot/alerts` should report zero open alerts.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` ✅ (all suites green)


<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-78
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->
