### PR TITLE
Prefix auth domain metrics with authotron

### DIFF
--- a/authotron/docs/src/api/endpoints.md
+++ b/authotron/docs/src/api/endpoints.md
@@ -138,13 +138,13 @@ Prometheus metrics endpoint.
 Example output:
 
 ```
-# HELP auth_requests_total Total authentication requests
-# TYPE auth_requests_total counter
-auth_requests_total{result="success",realm="internal"} 42
+# HELP authotron_auth_requests_total Total authentication requests
+# TYPE authotron_auth_requests_total counter
+authotron_auth_requests_total{result="success",realm="internal"} 42
 
-# HELP auth_duration_seconds Authentication latency
-# TYPE auth_duration_seconds histogram
-auth_duration_seconds_bucket{result="success",realm="internal",le="0.1"} 35
+# HELP authotron_auth_duration_seconds Authentication latency
+# TYPE authotron_auth_duration_seconds histogram
+authotron_auth_duration_seconds_bucket{result="success",realm="internal",le="0.1"} 35
 ```
 
 ## Endpoint Summary

--- a/authotron/docs/src/reference/metrics.md
+++ b/authotron/docs/src/reference/metrics.md
@@ -16,20 +16,20 @@ By default, this endpoint is available on port `9090`. The format follows the Pr
 
 | Metric Name | Type | Labels | Description |
 |-------------|------|--------|-------------|
-| `auth_requests_total` | Counter | result, realm | Total authentication requests |
-| `auth_duration_seconds` | Histogram | result, realm | Authentication latency distribution |
-| `auth_provider_attempts_total` | Counter | provider_name, provider_type, realm, result | Attempts per authentication provider |
-| `auth_provider_duration_seconds` | Histogram | provider_name, provider_type, realm | Provider-specific latency |
-| `augmenter_attempts_total` | Counter | augmenter_name, augmenter_type, realm, result | Token augmentation attempts |
-| `augmenter_duration_seconds` | Histogram | augmenter_type, realm | Augmentation latency |
+| `authotron_auth_requests_total` | Counter | result, realm | Total authentication requests |
+| `authotron_auth_duration_seconds` | Histogram | result, realm | Authentication latency distribution |
+| `authotron_auth_provider_attempts_total` | Counter | provider_name, provider_type, realm, result | Attempts per authentication provider |
+| `authotron_auth_provider_duration_seconds` | Histogram | provider_name, provider_type, realm | Provider-specific latency |
+| `authotron_augmenter_attempts_total` | Counter | augmenter_name, augmenter_type, realm, result | Token augmentation attempts |
+| `authotron_augmenter_duration_seconds` | Histogram | augmenter_type, realm | Augmentation latency |
 
 ## Label Values
 
-**result** (auth_requests_total): `success`, `no_auth_header`, `invalid_header`, `all_failed`
+**result** (authotron_auth_requests_total): `success`, `no_auth_header`, `invalid_header`, `all_failed`
 
-**result** (auth_provider_attempts_total): `success`, `error`, `timeout`
+**result** (authotron_auth_provider_attempts_total): `success`, `error`, `timeout`
 
-**result** (augmenter_attempts_total): `success`, `error`
+**result** (authotron_augmenter_attempts_total): `success`, `error`
 
 **realm**: The configured authentication realm name, or `unknown` when the request fails before realm resolution
 
@@ -46,37 +46,37 @@ By default, this endpoint is available on port `9090`. The format follows the Pr
 ### Request Rate
 
 ```promql
-rate(auth_requests_total[5m])
+rate(authotron_auth_requests_total[5m])
 ```
 
 ### Authentication Latency (99th Percentile)
 
 ```promql
-histogram_quantile(0.99, rate(auth_duration_seconds_bucket[5m]))
+histogram_quantile(0.99, rate(authotron_auth_duration_seconds_bucket[5m]))
 ```
 
 ### Error Rate by Realm
 
 ```promql
-rate(auth_requests_total{result!="success"}[5m])
+rate(authotron_auth_requests_total{result!="success"}[5m])
 ```
 
 ### Slow Providers (95th Percentile)
 
 ```promql
-histogram_quantile(0.95, rate(auth_provider_duration_seconds_bucket[5m]))
+histogram_quantile(0.95, rate(authotron_auth_provider_duration_seconds_bucket[5m]))
 ```
 
 ### Provider Success Rate
 
 ```promql
-rate(auth_provider_attempts_total{result="success"}[5m])
+rate(authotron_auth_provider_attempts_total{result="success"}[5m])
 ```
 
 ## Alerting Recommendations
 
 Consider alerting on:
 
-- High error rates: `rate(auth_requests_total{result!="success"}[5m]) > 0.1`
-- Elevated latency: `histogram_quantile(0.95, rate(auth_duration_seconds_bucket[5m])) > 1.0`
-- Provider failures: `rate(auth_provider_attempts_total{result=~"error|timeout"}[5m]) > 0`
+- High error rates: `rate(authotron_auth_requests_total{result!="success"}[5m]) > 0.1`
+- Elevated latency: `histogram_quantile(0.95, rate(authotron_auth_duration_seconds_bucket[5m])) > 1.0`
+- Provider failures: `rate(authotron_auth_provider_attempts_total{result=~"error|timeout"}[5m]) > 0`

--- a/authotron/src/auth.rs
+++ b/authotron/src/auth.rs
@@ -573,12 +573,13 @@ mod tests {
         // A MetricFamily groups all time series with the same metric name
         let metric_families = metrics.registry.gather();
 
-        // Search through each metric family (e.g., auth_requests_total, auth_duration_seconds)
+        // Search through each metric family (e.g., authotron_auth_requests_total,
+        // authotron_auth_duration_seconds)
         for mf in metric_families {
             // Check if this is the metric we're looking for
             if mf.name() == name {
                 // Each metric family contains multiple time series (one per label combination)
-                // For example, auth_requests_total has separate series for:
+                // For example, authotron_auth_requests_total has separate series for:
                 //   - {result="success", realm="test"}
                 //   - {result="failed", realm="test"}
                 //   - etc.
@@ -662,7 +663,7 @@ mod tests {
         // Verify exact metric values
         let success_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "success"), ("realm", "testrealm")],
         );
         assert_eq!(
@@ -672,7 +673,7 @@ mod tests {
 
         let provider_success = get_counter_value(
             &metrics,
-            "auth_provider_attempts_total",
+            "authotron_auth_provider_attempts_total",
             &[
                 ("provider_name", "TestProvider"),
                 ("provider_type", "Basic"),
@@ -687,7 +688,7 @@ mod tests {
 
         let duration_count = get_histogram_count(
             &metrics,
-            "auth_duration_seconds",
+            "authotron_auth_duration_seconds",
             &[("result", "success"), ("realm", "testrealm")],
         );
         assert_eq!(duration_count, 1, "Should have exactly 1 duration sample");
@@ -723,14 +724,14 @@ mod tests {
         // Verify failure was recorded
         let failed_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "all_failed"), ("realm", "unknown")],
         );
         assert_eq!(failed_count, 1.0, "Should record 1 failed attempt");
 
         let provider_error = get_counter_value(
             &metrics,
-            "auth_provider_attempts_total",
+            "authotron_auth_provider_attempts_total",
             &[
                 ("provider_name", "TestProvider"),
                 ("provider_type", "Basic"),
@@ -743,7 +744,7 @@ mod tests {
         // Verify no success was recorded
         let success_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "success"), ("realm", "testrealm")],
         );
         assert_eq!(success_count, 0.0, "Should have 0 successful attempts");
@@ -768,7 +769,7 @@ mod tests {
 
         let no_header_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "no_auth_header"), ("realm", "unknown")],
         );
         assert_eq!(no_header_count, 1.0, "Should record no_auth_header");
@@ -795,7 +796,7 @@ mod tests {
 
         let invalid_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "invalid_header"), ("realm", "unknown")],
         );
         assert_eq!(invalid_count, 1.0, "Should record invalid_header");
@@ -835,21 +836,21 @@ mod tests {
 
         let success_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "success"), ("realm", "test")],
         );
         assert_eq!(success_count, 3.0, "Should have exactly 3 successes");
 
         let failed_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "all_failed"), ("realm", "unknown")],
         );
         assert_eq!(failed_count, 2.0, "Should have exactly 2 failures");
 
         let total_duration_samples = get_histogram_count(
             &metrics,
-            "auth_duration_seconds",
+            "authotron_auth_duration_seconds",
             &[("result", "success"), ("realm", "test")],
         );
         assert_eq!(
@@ -892,7 +893,7 @@ mod tests {
 
         let augmenter_count = get_counter_value(
             &metrics,
-            "augmenter_attempts_total",
+            "authotron_augmenter_attempts_total",
             &[
                 ("augmenter_name", "test-aug"),
                 ("augmenter_type", "plain"),
@@ -905,7 +906,7 @@ mod tests {
 
         let aug_duration_samples = get_histogram_count(
             &metrics,
-            "augmenter_duration_seconds",
+            "authotron_augmenter_duration_seconds",
             &[("augmenter_type", "plain"), ("realm", "r1")],
         );
         assert_eq!(aug_duration_samples, 1, "Should record augmenter duration");
@@ -955,14 +956,14 @@ mod tests {
 
         let realm1_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "success"), ("realm", "realm1")],
         );
         assert_eq!(realm1_count, 1.0, "realm1 should have 1 success");
 
         let realm2_count = get_counter_value(
             &metrics,
-            "auth_requests_total",
+            "authotron_auth_requests_total",
             &[("result", "success"), ("realm", "realm2")],
         );
         assert_eq!(realm2_count, 1.0, "realm2 should have 1 success");

--- a/authotron/src/metrics/recorder.rs
+++ b/authotron/src/metrics/recorder.rs
@@ -141,16 +141,16 @@ impl Metrics {
         // Authentication metrics
         let auth_requests_total = register_counter_vec_with_registry!(
             Opts::new(
-                "auth_requests_total",
+                "authotron_auth_requests_total",
                 "Total number of authentication attempts"
             ),
             &["result", "realm"],
             registry.clone()
         )
-        .expect("Failed to register auth_requests_total");
+        .expect("Failed to register authotron_auth_requests_total");
 
         let auth_duration_seconds = register_histogram_vec_with_registry!(
-            "auth_duration_seconds",
+            "authotron_auth_duration_seconds",
             "Authentication request duration in seconds",
             &["result", "realm"],
             vec![
@@ -158,21 +158,21 @@ impl Metrics {
             ],
             registry.clone()
         )
-        .expect("Failed to register auth_duration_seconds");
+        .expect("Failed to register authotron_auth_duration_seconds");
 
         // Provider metrics
         let provider_attempts_total = register_counter_vec_with_registry!(
             Opts::new(
-                "auth_provider_attempts_total",
+                "authotron_auth_provider_attempts_total",
                 "Total authentication attempts per provider"
             ),
             &["provider_name", "provider_type", "realm", "result"],
             registry.clone()
         )
-        .expect("Failed to register provider_attempts_total");
+        .expect("Failed to register authotron_auth_provider_attempts_total");
 
         let provider_duration_seconds = register_histogram_vec_with_registry!(
-            "auth_provider_duration_seconds",
+            "authotron_auth_provider_duration_seconds",
             "Provider authentication duration in seconds",
             &["provider_name", "provider_type", "realm"],
             vec![
@@ -180,24 +180,27 @@ impl Metrics {
             ],
             registry.clone()
         )
-        .expect("Failed to register provider_duration_seconds");
+        .expect("Failed to register authotron_auth_provider_duration_seconds");
 
         // Augmenter metrics
         let augmenter_attempts_total = register_counter_vec_with_registry!(
-            Opts::new("augmenter_attempts_total", "Total augmenter executions"),
+            Opts::new(
+                "authotron_augmenter_attempts_total",
+                "Total augmenter executions"
+            ),
             &["augmenter_name", "augmenter_type", "realm", "result"],
             registry.clone()
         )
-        .expect("Failed to register augmenter_attempts_total");
+        .expect("Failed to register authotron_augmenter_attempts_total");
 
         let augmenter_duration_seconds = register_histogram_vec_with_registry!(
-            "augmenter_duration_seconds",
+            "authotron_augmenter_duration_seconds",
             "Augmenter execution duration in seconds",
             &["augmenter_type", "realm"],
             vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5],
             registry.clone()
         )
-        .expect("Failed to register augmenter_duration_seconds");
+        .expect("Failed to register authotron_augmenter_duration_seconds");
 
         let http_requests_total = register_int_counter_vec_with_registry!(
             Opts::new(
@@ -433,6 +436,47 @@ mod tests {
     }
 
     #[test]
+    fn auth_domain_metrics_use_authotron_prefix() {
+        let metrics = Metrics::new();
+        metrics.preinit_series(
+            &[("provider".into(), "plain".into(), "realm".into())],
+            &[("augmenter".into(), "plain".into(), "realm".into())],
+        );
+
+        let names: BTreeSet<_> = metrics
+            .registry
+            .gather()
+            .into_iter()
+            .map(|family| family.name().to_owned())
+            .collect();
+        let expected = [
+            "authotron_auth_requests_total",
+            "authotron_auth_duration_seconds",
+            "authotron_auth_provider_attempts_total",
+            "authotron_auth_provider_duration_seconds",
+            "authotron_augmenter_attempts_total",
+            "authotron_augmenter_duration_seconds",
+        ];
+
+        for name in expected {
+            assert!(names.contains(name), "missing prefixed metric {name}");
+        }
+        for old_name in [
+            "auth_requests_total",
+            "auth_duration_seconds",
+            "auth_provider_attempts_total",
+            "auth_provider_duration_seconds",
+            "augmenter_attempts_total",
+            "augmenter_duration_seconds",
+        ] {
+            assert!(
+                !names.contains(old_name),
+                "legacy metric still exposed: {old_name}"
+            );
+        }
+    }
+
+    #[test]
     fn preinit_series_creates_zero_baseline_for_reachable_labels() {
         let metrics = Metrics::new();
         let providers = vec![(
@@ -450,14 +494,14 @@ mod tests {
         let output = metrics.render().expect("render ok");
         for series in [
             // provider error/timeout pre-initialised at zero
-            r#"auth_provider_attempts_total{provider_name="plain1",provider_type="plain",realm="realm1",result="error"} 0"#,
-            r#"auth_provider_attempts_total{provider_name="plain1",provider_type="plain",realm="realm1",result="timeout"} 0"#,
+            r#"authotron_auth_provider_attempts_total{provider_name="plain1",provider_type="plain",realm="realm1",result="error"} 0"#,
+            r#"authotron_auth_provider_attempts_total{provider_name="plain1",provider_type="plain",realm="realm1",result="timeout"} 0"#,
             // augmenter error pre-initialised at zero
-            r#"augmenter_attempts_total{augmenter_name="aug1",augmenter_type="plain",realm="realm1",result="error"} 0"#,
+            r#"authotron_augmenter_attempts_total{augmenter_name="aug1",augmenter_type="plain",realm="realm1",result="error"} 0"#,
             // auth failure recorded only with realm="unknown"
-            r#"auth_requests_total{realm="unknown",result="all_failed"} 0"#,
+            r#"authotron_auth_requests_total{realm="unknown",result="all_failed"} 0"#,
             // auth success with the configured realm
-            r#"auth_requests_total{realm="realm1",result="success"} 0"#,
+            r#"authotron_auth_requests_total{realm="realm1",result="success"} 0"#,
         ] {
             assert!(
                 output.contains(series),
@@ -530,7 +574,8 @@ mod tests {
 
         let output = metrics.render().expect("render ok");
         assert!(
-            !output.contains(r#"auth_requests_total{realm="realm1",result="all_failed"}"#),
+            !output
+                .contains(r#"authotron_auth_requests_total{realm="realm1",result="all_failed"}"#),
             "must not pre-init failure×configured-realm combos:\n{output}"
         );
     }


### PR DESCRIPTION
## Changelog
- Rename the six auth-domain Prometheus metrics to the `authotron_*` namespace.
- Update repository tests, metrics documentation, and PromQL examples.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features -- --test-threads=1`

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-79
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->