### PR TITLE
Harden authentication response handling

### DIFF
--- a/authotron/src/routes/auth.rs
+++ b/authotron/src/routes/auth.rs
@@ -9,8 +9,8 @@
 //! Authentication endpoint handlers.
 
 use axum::body::Body;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::{Router, routing::get};
 use http::HeaderValue;
 
@@ -34,24 +34,155 @@ async fn authenticate(
 ) -> Result<impl IntoResponse, HTTPError> {
     let jwt = user.to_jwt(&state.config.jwt);
 
-    let mut response_builder = axum::http::response::Response::builder()
+    authentication_response(
+        &user,
+        jwt,
+        state.config.include_legacy_headers.unwrap_or(false),
+    )
+}
+
+fn authentication_response(
+    user: &User,
+    jwt: String,
+    include_legacy_headers: bool,
+) -> Result<Response<Body>, HTTPError> {
+    let mut response = axum::http::response::Response::builder()
         .status(StatusCode::OK)
         .header("Authorization", format!("Bearer {}", jwt))
         .body(Body::from("Authenticated successfully"))
-        .map_err(|e| HTTPError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string(), None))?;
+        .map_err(|_| internal_server_error())?;
 
-    if state.config.include_legacy_headers.unwrap_or(false) {
-        let headers = response_builder.headers_mut();
-        headers.append(
-            "X-Auth-Username",
-            HeaderValue::from_str(&user.username).unwrap(),
+    if include_legacy_headers {
+        add_legacy_headers(response.headers_mut(), user)?;
+    }
+
+    Ok(response)
+}
+
+fn add_legacy_headers(headers: &mut HeaderMap, user: &User) -> Result<(), HTTPError> {
+    // Convert every value before mutating the response so an invalid value cannot
+    // leave a partially populated legacy-header set.
+    let username = legacy_header_value(&user.username)?;
+    let realm = legacy_header_value(&user.realm)?;
+    let roles = legacy_header_value(&user.roles.join(","))?;
+
+    headers.append("X-Auth-Username", username);
+    headers.append("X-Auth-Realm", realm);
+    headers.append("X-Auth-Roles", roles);
+
+    Ok(())
+}
+
+fn legacy_header_value(value: &str) -> Result<HeaderValue, HTTPError> {
+    HeaderValue::from_str(value).map_err(|_| internal_server_error())
+}
+
+fn internal_server_error() -> HTTPError {
+    HTTPError::new(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Internal server error",
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    fn user(username: &str, realm: &str, roles: &[&str]) -> User {
+        User::new(
+            realm.to_string(),
+            username.to_string(),
+            Some(roles.iter().map(|role| (*role).to_string()).collect()),
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn successful_response_remains_compatible() {
+        let response = authentication_response(
+            &user("alice", "operations", &["reader", "writer"]),
+            "signed.jwt".to_string(),
+            true,
+        )
+        .expect("valid legacy headers should produce a response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["Authorization"], "Bearer signed.jwt");
+        assert_eq!(response.headers()["X-Auth-Username"], "alice");
+        assert_eq!(response.headers()["X-Auth-Realm"], "operations");
+        assert_eq!(response.headers()["X-Auth-Roles"], "reader,writer");
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("success body should be readable");
+        assert_eq!(body.as_ref(), b"Authenticated successfully");
+    }
+
+    #[test]
+    fn unicode_legacy_header_values_are_preserved() {
+        let response = authentication_response(
+            &user("álîçé", "météo", &["données", "观测"]),
+            "signed.jwt".to_string(),
+            true,
+        )
+        .expect("unicode legacy headers should produce a response");
+
+        assert_eq!(
+            response.headers()["X-Auth-Username"].as_bytes(),
+            "álîçé".as_bytes()
         );
-        headers.append("X-Auth-Realm", HeaderValue::from_str(&user.realm).unwrap());
-        headers.append(
-            "X-Auth-Roles",
-            HeaderValue::from_str(&user.roles.join(",")).unwrap(),
+        assert_eq!(
+            response.headers()["X-Auth-Realm"].as_bytes(),
+            "météo".as_bytes()
+        );
+        assert_eq!(
+            response.headers()["X-Auth-Roles"].as_bytes(),
+            "données,观测".as_bytes()
         );
     }
 
-    Ok(response_builder)
+    #[tokio::test]
+    async fn control_bearing_legacy_values_return_a_generic_error() {
+        let users = [
+            user("ali\nce", "operations", &["reader"]),
+            user("alice", "oper\rations", &["reader"]),
+            user("alice", "operations", &["read\u{0000}er"]),
+        ];
+
+        for user in users {
+            let result = authentication_response(&user, "signed.jwt".to_string(), true);
+            let Err(error) = result else {
+                panic!("control-bearing legacy header should be rejected");
+            };
+
+            let response = error.into_response();
+            assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+            let body = to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("error body should be readable");
+            let json: serde_json::Value =
+                serde_json::from_slice(&body).expect("error body should be valid JSON");
+            assert_eq!(json["error"], "Internal server error");
+        }
+    }
+
+    #[test]
+    fn invalid_values_do_not_matter_when_legacy_headers_are_disabled() {
+        let response = authentication_response(
+            &user("ali\nce", "oper\rations", &["read\u{0000}er"]),
+            "signed.jwt".to_string(),
+            false,
+        )
+        .expect("legacy values should not be inspected when headers are disabled");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(!response.headers().contains_key("X-Auth-Username"));
+        assert!(!response.headers().contains_key("X-Auth-Realm"));
+        assert!(!response.headers().contains_key("X-Auth-Roles"));
+    }
 }

--- a/authotron/src/utils/http_helpers.rs
+++ b/authotron/src/utils/http_helpers.rs
@@ -6,12 +6,15 @@
 // granted to it by virtue of its status as an intergovernmental organisation nor
 // does it submit to any jurisdiction.
 
-use axum::http::StatusCode;
+use axum::Json;
+use axum::http::{HeaderValue, StatusCode, header::WWW_AUTHENTICATE};
 use axum::response::{IntoResponse, Response};
+use serde::Serialize;
 
 /// HTTPError is our custom error type returned by our request extractor.
 /// It now carries an optional challenge string that is used to dynamically
 /// populate the WWW-Authenticate header for unauthorized responses.
+#[derive(Debug)]
 pub struct HTTPError {
     status: StatusCode,
     message: String,
@@ -29,23 +32,98 @@ impl HTTPError {
     }
 }
 
+#[derive(Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
 /// Convert the HTTPError into an HTTP response.
-/// If the status is 401 Unauthorized and a challenge is provided,
+/// If the status is 401 Unauthorized and a valid challenge is provided,
 /// we include it as the WWW-Authenticate header.
 impl IntoResponse for HTTPError {
     fn into_response(self) -> Response {
-        let body = format!("{{\"error\": \"{}\"}}", self.message);
-        let mut builder = Response::builder()
-            .status(self.status)
-            .header("Content-Type", "application/json");
+        let mut response = (
+            self.status,
+            Json(ErrorBody {
+                error: self.message,
+            }),
+        )
+            .into_response();
 
-        if self.status == StatusCode::UNAUTHORIZED {
-            // If a challenge is provided, use it.
-            if let Some(challenge) = self.challenge {
-                builder = builder.header("WWW-Authenticate", challenge);
-            }
+        if self.status == StatusCode::UNAUTHORIZED
+            && let Some(challenge) = self.challenge
+            && let Ok(value) = HeaderValue::from_str(&challenge)
+        {
+            response.headers_mut().insert(WWW_AUTHENTICATE, value);
         }
 
-        builder.body(body.into()).unwrap()
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn error_message_is_serialized_as_json() {
+        let message = "quote: \"; slash: /; backslash: \\; newline:\n; controls: \u{0000}\u{0007}";
+        let response = HTTPError::new(StatusCode::BAD_REQUEST, message, None).into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.headers()["Content-Type"], "application/json");
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("error body should be readable");
+        let json: serde_json::Value =
+            serde_json::from_slice(&body).expect("error body should be valid JSON");
+        assert_eq!(json["error"], message);
+    }
+
+    #[tokio::test]
+    async fn malformed_www_authenticate_header_is_omitted() {
+        let response = HTTPError::new(
+            StatusCode::UNAUTHORIZED,
+            "Unauthorized access",
+            Some("Bearer realm=\"bad\nrealm\"".to_string()),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(!response.headers().contains_key(WWW_AUTHENTICATE));
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("error body should be readable");
+        let json: serde_json::Value =
+            serde_json::from_slice(&body).expect("error body should be valid JSON");
+        assert_eq!(json["error"], "Unauthorized access");
+    }
+
+    #[test]
+    fn valid_www_authenticate_header_is_preserved() {
+        let challenge = "Basic realm=\"operations\", Bearer";
+        let response = HTTPError::new(
+            StatusCode::UNAUTHORIZED,
+            "Unauthorized access",
+            Some(challenge.to_string()),
+        )
+        .into_response();
+
+        assert_eq!(response.headers()[WWW_AUTHENTICATE], challenge);
+    }
+
+    #[test]
+    fn challenge_is_only_added_to_unauthorized_responses() {
+        let response = HTTPError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal server error",
+            Some("Bearer".to_string()),
+        )
+        .into_response();
+
+        assert!(!response.headers().contains_key(WWW_AUTHENTICATE));
     }
 }


### PR DESCRIPTION
## Changelog

- Validate legacy authentication headers and return a generic 500 for invalid values.
- Serialize HTTP errors as JSON and omit malformed `WWW-Authenticate` headers.
- Rename the built authentication response variable and add response-safety regression tests.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo build --workspace --release`
- `mdbook build` (`authotron/docs`)


<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-81
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->