### PR TITLE
Improve runtime shutdown and startup reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "http",
  "jsonwebtoken",
  "ldap3",
+ "libc",
  "mockito",
  "mongodb",
  "prometheus",

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -62,5 +62,5 @@ mockito = "~1.7"
 tower = { version = "~0.5", features = ["util"] }
 tracing-test = "~0.2"
 
-[target.'cfg(unix)'.dev-dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "~0.2"

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["authentication", "authorization", "gateway", "jwt", "nginx"]
 categories = ["authentication", "network-programming"]
 rust-version = "1.88"
 include = [
-    "src/**/*.rs",
-    "src/static/**",
-    "Cargo.toml",
-    "LICENSE.txt",
-    "README.md",
+  "src/**/*.rs",
+  "src/static/**",
+  "Cargo.toml",
+  "LICENSE.txt",
+  "README.md",
 ]
 
 [dependencies]
@@ -61,3 +61,6 @@ uuid = { version = "~1.22", features = ["v4"] }
 mockito = "~1.7"
 tower = { version = "~0.5", features = ["util"] }
 tracing-test = "~0.2"
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "~0.2"

--- a/authotron/docs/src/configuration/logging.md
+++ b/authotron/docs/src/configuration/logging.md
@@ -23,6 +23,8 @@ The `level` field controls which messages are emitted. Messages at the configure
 | warn | Warning conditions that are not errors |
 | error | Error conditions |
 
+Values are case-insensitive. Any other value is a startup error; Auth-O-Tron reports it to standard error and exits without starting either server. Failure to install the process-wide tracing subscriber is handled the same way.
+
 ## Log Formats
 
 ### Console Format

--- a/authotron/docs/src/configuration/server.md
+++ b/authotron/docs/src/configuration/server.md
@@ -69,6 +69,10 @@ The application server and metrics server expose different endpoints:
 
 Note that `/health` is available on both servers when metrics are enabled. When `metrics.enabled: false`, `/health` is only served on the application port.
 
+## Graceful Shutdown
+
+On `SIGINT` or `SIGTERM`, Auth-O-Tron stops accepting new connections and waits for in-flight requests to finish before shutting down. A single shutdown notification coordinates the application server and the metrics server. The same behavior applies to the application server when metrics are disabled.
+
 ## Port Collision Detection
 
 Auth-O-Tron validates that the application port and metrics port are different. If you accidentally configure them to the same value, the server will fail to start with an error message explaining the conflict.

--- a/authotron/src/main.rs
+++ b/authotron/src/main.rs
@@ -12,28 +12,35 @@ use authotron::config::{load_config, print_schema};
 use authotron::startup;
 use authotron::utils::logger::init_logging;
 use std::env;
+use std::process::ExitCode;
 use std::sync::Arc;
+
 use tracing::error;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
 
     if args.contains(&"--schema".to_string()) {
         print_schema();
-        return;
+        return ExitCode::SUCCESS;
     }
 
     let config = Arc::new(load_config());
-    init_logging(&config.logging);
+    if let Err(error) = init_logging(&config.logging) {
+        eprintln!("Error initializing logging: {error}");
+        return ExitCode::FAILURE;
+    }
 
-    if let Err(e) = startup::run(config).await {
+    if let Err(error) = startup::run(config).await {
         error!(
             event_name = "startup.server.failed",
             event_domain = "startup",
-            error = %e,
+            error = %error,
             "server error"
         );
-        std::process::exit(1);
+        return ExitCode::FAILURE;
     }
+
+    ExitCode::SUCCESS
 }

--- a/authotron/src/routes/homepage.rs
+++ b/authotron/src/routes/homepage.rs
@@ -6,12 +6,16 @@
 // granted to it by virtue of its status as an intergovernmental organisation nor
 // does it submit to any jurisdiction.
 
+use std::sync::LazyLock;
+
 use crate::state::AppState;
 use axum::{Router, http::header, response::IntoResponse, routing::get};
 
 const TEMPLATE: &str = include_str!("../static/index.html");
 const LOGO: &[u8] = include_bytes!("../static/logo.png");
 const FAVICON: &[u8] = include_bytes!("../static/favicon.ico");
+static HOMEPAGE: LazyLock<String> =
+    LazyLock::new(|| TEMPLATE.replace("{{version}}", env!("CARGO_PKG_VERSION")));
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -21,8 +25,10 @@ pub fn routes() -> Router<AppState> {
 }
 
 async fn index() -> impl IntoResponse {
-    let html = TEMPLATE.replace("{{version}}", env!("CARGO_PKG_VERSION"));
-    ([(header::CONTENT_TYPE, "text/html; charset=utf-8")], html)
+    (
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        HOMEPAGE.as_str(),
+    )
 }
 
 async fn logo() -> impl IntoResponse {

--- a/authotron/src/startup.rs
+++ b/authotron/src/startup.rs
@@ -11,8 +11,12 @@
 //! Starts the application server and, when enabled, a dedicated metrics/health server
 //! on a separate port.
 
+use std::fmt::{self, Display, Formatter};
+use std::io;
 use std::sync::Arc;
+
 use tokio::net::TcpListener;
+use tokio::sync::watch;
 use tracing::info;
 
 use crate::auth::Auth;
@@ -77,7 +81,105 @@ pub async fn build_app(
     Ok((app, state))
 }
 
-pub async fn run(config: Arc<ConfigV2>) -> Result<(), Box<dyn std::error::Error>> {
+/// Coordinates graceful shutdown across all running HTTP servers.
+#[derive(Clone, Debug)]
+pub struct ShutdownCoordinator {
+    sender: watch::Sender<bool>,
+}
+
+/// A shutdown notification for one server.
+#[derive(Debug)]
+pub struct ShutdownSignal {
+    receiver: watch::Receiver<bool>,
+}
+
+impl ShutdownCoordinator {
+    /// Create a coordinator whose shutdown has not yet been requested.
+    pub fn new() -> Self {
+        let (sender, _) = watch::channel(false);
+        Self { sender }
+    }
+
+    /// Subscribe one server to the shared shutdown notification.
+    pub fn subscribe(&self) -> ShutdownSignal {
+        ShutdownSignal {
+            receiver: self.sender.subscribe(),
+        }
+    }
+
+    /// Notify all current and future subscribers that shutdown was requested.
+    pub fn shutdown(&self) {
+        self.sender.send_replace(true);
+    }
+}
+
+impl Default for ShutdownCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ShutdownSignal {
+    /// Wait until the coordinator requests shutdown.
+    pub async fn wait(mut self) {
+        while !*self.receiver.borrow() {
+            if self.receiver.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ShutdownReason {
+    Interrupt,
+    Terminate,
+}
+
+impl Display for ShutdownReason {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Interrupt => formatter.write_str("SIGINT"),
+            Self::Terminate => formatter.write_str("SIGTERM"),
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() -> io::Result<ShutdownReason> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut terminate = signal(SignalKind::terminate())?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result?;
+            Ok(ShutdownReason::Interrupt)
+        }
+        signal = terminate.recv() => signal
+            .map(|_| ShutdownReason::Terminate)
+            .ok_or_else(|| io::Error::other("SIGTERM signal stream closed")),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() -> io::Result<ShutdownReason> {
+    tokio::signal::ctrl_c().await?;
+    Ok(ShutdownReason::Interrupt)
+}
+
+fn server_shutdown_signals(
+    coordinator: &ShutdownCoordinator,
+    metrics_enabled: bool,
+) -> (ShutdownSignal, Option<ShutdownSignal>) {
+    let app = coordinator.subscribe();
+    let metrics = metrics_enabled.then(|| coordinator.subscribe());
+    (app, metrics)
+}
+
+async fn run_servers(
+    config: Arc<ConfigV2>,
+    shutdown: ShutdownCoordinator,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (app, state) = build_app(config.clone()).await?;
 
     if config.metrics.enabled && config.server.port == config.metrics.port {
@@ -91,9 +193,9 @@ pub async fn run(config: Arc<ConfigV2>) -> Result<(), Box<dyn std::error::Error>
     let host = config.server.host.as_str();
     let app_listener = TcpListener::bind((host, config.server.port))
         .await
-        .map_err(|e| {
+        .map_err(|error| {
             format!(
-                "could not bind application server on {}:{}: {e}",
+                "could not bind application server on {}:{}: {error}",
                 host, config.server.port
             )
         })?;
@@ -106,13 +208,21 @@ pub async fn run(config: Arc<ConfigV2>) -> Result<(), Box<dyn std::error::Error>
         "application server listening"
     );
 
-    if config.metrics.enabled {
+    let (app_shutdown, metrics_shutdown) =
+        server_shutdown_signals(&shutdown, config.metrics.enabled);
+    let app_server = axum::serve(
+        app_listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(app_shutdown.wait());
+
+    if let Some(metrics_shutdown) = metrics_shutdown {
         let metrics_router = routes::create_metrics_router(state);
         let metrics_listener = TcpListener::bind((host, config.metrics.port))
             .await
-            .map_err(|e| {
+            .map_err(|error| {
                 format!(
-                    "could not bind metrics server on {}:{}: {e}",
+                    "could not bind metrics server on {}:{}: {error}",
                     host, config.metrics.port
                 )
             })?;
@@ -125,34 +235,83 @@ pub async fn run(config: Arc<ConfigV2>) -> Result<(), Box<dyn std::error::Error>
             "metrics server listening"
         );
 
-        tokio::try_join!(
-            async {
-                axum::serve(
-                    app_listener,
-                    app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-                )
-                .await
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
-            },
-            async {
-                axum::serve(metrics_listener, metrics_router)
-                    .await
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
-            }
-        )?;
+        let metrics_server = axum::serve(metrics_listener, metrics_router)
+            .with_graceful_shutdown(metrics_shutdown.wait());
+        tokio::try_join!(app_server, metrics_server)?;
     } else {
         info!(
             event_name = "startup.metrics.disabled",
             event_domain = "startup",
             "metrics server disabled"
         );
-
-        axum::serve(
-            app_listener,
-            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-        )
-        .await?;
+        app_server.await?;
     }
 
     Ok(())
+}
+
+async fn coordinate_shutdown(
+    coordinator: ShutdownCoordinator,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let reason = wait_for_shutdown_signal().await?;
+    info!(
+        event_name = "startup.shutdown.requested",
+        event_domain = "startup",
+        signal = %reason,
+        "shutdown requested; draining HTTP servers"
+    );
+    coordinator.shutdown();
+    Ok(())
+}
+
+/// Start the application and metrics servers and stop them gracefully on SIGINT or SIGTERM.
+pub async fn run(config: Arc<ConfigV2>) -> Result<(), Box<dyn std::error::Error>> {
+    let coordinator = ShutdownCoordinator::new();
+    tokio::try_join!(
+        run_servers(config, coordinator.clone()),
+        coordinate_shutdown(coordinator),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn coordinator_notifies_all_servers_and_late_subscribers() {
+        let coordinator = ShutdownCoordinator::new();
+        let (app_shutdown, metrics_shutdown) = server_shutdown_signals(&coordinator, true);
+        let app = tokio::spawn(app_shutdown.wait());
+        let metrics = tokio::spawn(metrics_shutdown.expect("metrics signal").wait());
+
+        tokio::task::yield_now().await;
+        assert!(!app.is_finished());
+        assert!(!metrics.is_finished());
+
+        coordinator.shutdown();
+        timeout(Duration::from_secs(1), app)
+            .await
+            .expect("application server received shutdown")
+            .expect("application shutdown task completed");
+        timeout(Duration::from_secs(1), metrics)
+            .await
+            .expect("metrics server received shutdown")
+            .expect("metrics shutdown task completed");
+        timeout(Duration::from_secs(1), coordinator.subscribe().wait())
+            .await
+            .expect("late subscriber observed prior shutdown");
+    }
+
+    #[test]
+    fn metrics_disabled_does_not_create_a_metrics_signal() {
+        let coordinator = ShutdownCoordinator::new();
+        let (_, metrics_shutdown) = server_shutdown_signals(&coordinator, false);
+
+        assert!(metrics_shutdown.is_none());
+    }
 }

--- a/authotron/src/startup.rs
+++ b/authotron/src/startup.rs
@@ -182,7 +182,10 @@ async fn run_servers(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (app, state) = build_app(config.clone()).await?;
 
-    if config.metrics.enabled && config.server.port == config.metrics.port {
+    if config.metrics.enabled
+        && config.server.port != 0
+        && config.server.port == config.metrics.port
+    {
         return Err(format!(
             "application port and metrics port are both {}, they must be different",
             config.server.port
@@ -200,11 +203,13 @@ async fn run_servers(
             )
         })?;
 
+    let app_port = app_listener.local_addr()?.port();
+
     info!(
         event_name = "startup.server.listening",
         event_domain = "startup",
         host,
-        port = config.server.port,
+        port = app_port,
         "application server listening"
     );
 
@@ -227,11 +232,13 @@ async fn run_servers(
                 )
             })?;
 
+        let metrics_port = metrics_listener.local_addr()?.port();
+
         info!(
             event_name = "startup.metrics.listening",
             event_domain = "startup",
             host,
-            port = config.metrics.port,
+            port = metrics_port,
             "metrics server listening"
         );
 

--- a/authotron/src/startup.rs
+++ b/authotron/src/startup.rs
@@ -176,16 +176,106 @@ fn server_shutdown_signals(
     (app, metrics)
 }
 
+#[derive(Clone, Copy)]
+enum ServerKind {
+    Application,
+    Metrics,
+}
+
+impl Display for ServerKind {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Application => formatter.write_str("application"),
+            Self::Metrics => formatter.write_str("metrics"),
+        }
+    }
+}
+
+#[cfg(all(unix, debug_assertions))]
+impl ServerKind {
+    fn test_listener_environment(self) -> &'static str {
+        match self {
+            Self::Application => "AUTHOTRON_TEST_APP_LISTENER_FD",
+            Self::Metrics => "AUTHOTRON_TEST_METRICS_LISTENER_FD",
+        }
+    }
+}
+
+#[cfg(all(unix, debug_assertions))]
+fn listener_from_test_environment(
+    kind: ServerKind,
+    host: &str,
+    port: u16,
+) -> io::Result<Option<TcpListener>> {
+    use std::env;
+    use std::net::IpAddr;
+    use std::os::fd::{FromRawFd, OwnedFd};
+
+    let environment = kind.test_listener_environment();
+    let Some(value) = env::var_os(environment) else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .ok_or_else(|| io::Error::other(format!("{environment} is not valid UTF-8")))?;
+    let inherited_fd = value.parse::<libc::c_int>().map_err(|error| {
+        io::Error::other(format!(
+            "{environment} must contain a file descriptor: {error}"
+        ))
+    })?;
+
+    // Duplicate first so an invalid environment value is reported by the OS rather than
+    // being passed to `OwnedFd::from_raw_fd`, which requires a valid, owned descriptor.
+    // SAFETY: `fcntl` does not dereference pointers, and a successful `F_DUPFD_CLOEXEC`
+    // returns a new descriptor owned by this process.
+    let listener_fd = unsafe { libc::fcntl(inherited_fd, libc::F_DUPFD_CLOEXEC, 0) };
+    if listener_fd == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: the successful `fcntl` call above returned a new descriptor that this
+    // process owns and has not transferred elsewhere.
+    let listener_fd = unsafe { OwnedFd::from_raw_fd(listener_fd) };
+    let listener = std::net::TcpListener::from(listener_fd);
+    listener.set_nonblocking(true)?;
+
+    let actual_address = listener.local_addr()?;
+    if actual_address.port() != port {
+        return Err(io::Error::other(format!(
+            "pre-bound {kind} listener uses port {}, but configuration uses {port}",
+            actual_address.port()
+        )));
+    }
+    if let Ok(expected_ip) = host.parse::<IpAddr>()
+        && actual_address.ip() != expected_ip
+    {
+        return Err(io::Error::other(format!(
+            "pre-bound {kind} listener uses address {}, but configuration uses {host}",
+            actual_address.ip()
+        )));
+    }
+
+    TcpListener::from_std(listener).map(Some)
+}
+
+async fn bind_listener(host: &str, port: u16, kind: ServerKind) -> io::Result<TcpListener> {
+    #[cfg(all(unix, debug_assertions))]
+    if let Some(listener) = listener_from_test_environment(kind, host, port)? {
+        return Ok(listener);
+    }
+
+    #[cfg(not(all(unix, debug_assertions)))]
+    let _ = kind;
+
+    TcpListener::bind((host, port)).await
+}
+
 async fn run_servers(
     config: Arc<ConfigV2>,
     shutdown: ShutdownCoordinator,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (app, state) = build_app(config.clone()).await?;
 
-    if config.metrics.enabled
-        && config.server.port != 0
-        && config.server.port == config.metrics.port
-    {
+    if config.metrics.enabled && config.server.port == config.metrics.port {
         return Err(format!(
             "application port and metrics port are both {}, they must be different",
             config.server.port
@@ -194,7 +284,7 @@ async fn run_servers(
     }
 
     let host = config.server.host.as_str();
-    let app_listener = TcpListener::bind((host, config.server.port))
+    let app_listener = bind_listener(host, config.server.port, ServerKind::Application)
         .await
         .map_err(|error| {
             format!(
@@ -223,7 +313,7 @@ async fn run_servers(
 
     if let Some(metrics_shutdown) = metrics_shutdown {
         let metrics_router = routes::create_metrics_router(state);
-        let metrics_listener = TcpListener::bind((host, config.metrics.port))
+        let metrics_listener = bind_listener(host, config.metrics.port, ServerKind::Metrics)
             .await
             .map_err(|error| {
                 format!(

--- a/authotron/src/utils/logger.rs
+++ b/authotron/src/utils/logger.rs
@@ -6,6 +6,9 @@
 // granted to it by virtue of its status as an intergovernmental organisation nor
 // does it submit to any jurisdiction.
 
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
 use tracing::level_filters::LevelFilter;
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::fmt::format::Writer;
@@ -143,49 +146,137 @@ where
     }
 }
 
-pub fn init_logging(logging_config: &LoggingConfig) {
-    // Parse level string -> LevelFilter
-    let level_filter = match logging_config.level.trim().to_lowercase().as_str() {
-        "trace" => LevelFilter::TRACE,
-        "debug" => LevelFilter::DEBUG,
-        "info" => LevelFilter::INFO,
-        "warn" => LevelFilter::WARN,
-        "error" => LevelFilter::ERROR,
-        _ => {
-            panic!(
-                "Invalid logging.level '{}'. Valid values: trace, debug, info, warn, error",
-                logging_config.level
-            );
-        }
-    };
+/// Errors that can occur while configuring the global tracing subscriber.
+#[derive(Debug)]
+pub enum LoggingInitError {
+    /// The configured logging level is not supported.
+    InvalidLevel { level: String },
+    /// The tracing subscriber could not be installed globally.
+    SubscriberInitialization {
+        source: Box<dyn Error + Send + Sync>,
+    },
+}
 
-    // This can be used to allow env-based overrides, plus the default:
+impl Display for LoggingInitError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidLevel { level } => write!(
+                formatter,
+                "invalid logging.level '{level}'; valid values: trace, debug, info, warn, error"
+            ),
+            Self::SubscriberInitialization { source } => {
+                write!(
+                    formatter,
+                    "could not initialize logging subscriber: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for LoggingInitError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidLevel { .. } => None,
+            Self::SubscriberInitialization { source } => Some(source.as_ref()),
+        }
+    }
+}
+
+type BoxedSubscriber = Box<dyn Subscriber + Send + Sync>;
+
+fn parse_level(level: &str) -> Result<LevelFilter, LoggingInitError> {
+    match level.trim().to_lowercase().as_str() {
+        "trace" => Ok(LevelFilter::TRACE),
+        "debug" => Ok(LevelFilter::DEBUG),
+        "info" => Ok(LevelFilter::INFO),
+        "warn" => Ok(LevelFilter::WARN),
+        "error" => Ok(LevelFilter::ERROR),
+        _ => Err(LoggingInitError::InvalidLevel {
+            level: level.to_owned(),
+        }),
+    }
+}
+
+fn init_logging_with(
+    logging_config: &LoggingConfig,
+    initialize: impl FnOnce(BoxedSubscriber) -> Result<(), Box<dyn Error + Send + Sync>>,
+) -> Result<(), LoggingInitError> {
+    let level_filter = parse_level(&logging_config.level)?;
     let filter_layer = EnvFilter::default().add_directive(level_filter.into());
 
-    match logging_config.format.to_lowercase().as_str() {
-        "json" => {
-            // OTel-aligned structured JSON output
+    let subscriber: BoxedSubscriber = match logging_config.format.to_lowercase().as_str() {
+        "json" => Box::new(tracing_subscriber::registry().with(filter_layer).with(
+            fmt::layer().event_format(OtelJsonEventFormatter {
+                service_name: logging_config.service_name.clone(),
+                service_version: logging_config.service_version.clone(),
+            }),
+        )),
+        _ => Box::new(
             tracing_subscriber::registry()
                 .with(filter_layer)
-                .with(fmt::layer().event_format(OtelJsonEventFormatter {
-                    service_name: logging_config.service_name.clone(),
-                    service_version: logging_config.service_version.clone(),
-                }))
-                .init();
+                .with(fmt::layer().pretty()),
+        ),
+    };
+
+    initialize(subscriber).map_err(|source| LoggingInitError::SubscriberInitialization { source })
+}
+
+/// Configure and install the process-wide tracing subscriber.
+pub fn init_logging(logging_config: &LoggingConfig) -> Result<(), LoggingInitError> {
+    init_logging_with(logging_config, |subscriber| {
+        tracing::subscriber::set_global_default(subscriber)
+            .map_err(|error| Box::new(error) as Box<dyn Error + Send + Sync>)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    fn logging_config(level: &str) -> LoggingConfig {
+        LoggingConfig {
+            level: level.to_owned(),
+            format: "console".to_owned(),
+            service_name: "authotron-test".to_owned(),
+            service_version: "test".to_owned(),
         }
-        "console" => {
-            // Human-readable console output with ANSI colors
-            tracing_subscriber::registry()
-                .with(filter_layer)
-                .with(fmt::layer().pretty())
-                .init();
+    }
+
+    #[test]
+    fn accepts_all_supported_levels() {
+        for level in ["trace", "debug", "info", "warn", "error"] {
+            let result = init_logging_with(&logging_config(level), |_| Ok(()));
+            assert!(result.is_ok(), "expected {level} to be supported");
         }
-        _ => {
-            // Fallback to console if unknown
-            tracing_subscriber::registry()
-                .with(filter_layer)
-                .with(fmt::layer().pretty())
-                .init();
-        }
+    }
+
+    #[test]
+    fn rejects_invalid_level() {
+        let result = init_logging_with(&logging_config("verbose"), |_| Ok(()));
+
+        assert!(matches!(
+            result,
+            Err(LoggingInitError::InvalidLevel { level }) if level == "verbose"
+        ));
+    }
+
+    #[test]
+    fn reports_subscriber_initialization_failure() {
+        let result = init_logging_with(&logging_config("info"), |_| {
+            Err(Box::new(io::Error::other("subscriber already installed"))
+                as Box<dyn Error + Send + Sync>)
+        });
+
+        assert!(matches!(
+            &result,
+            Err(LoggingInitError::SubscriberInitialization { .. })
+        ));
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "could not initialize logging subscriber: subscriber already installed"
+        );
     }
 }

--- a/authotron/tests/logging_integration.rs
+++ b/authotron/tests/logging_integration.rs
@@ -1,0 +1,23 @@
+use authotron::config::LoggingConfig;
+use authotron::utils::logger::{LoggingInitError, init_logging};
+
+fn logging_config() -> LoggingConfig {
+    LoggingConfig {
+        level: "info".to_owned(),
+        format: "console".to_owned(),
+        service_name: "authotron-test".to_owned(),
+        service_version: "test".to_owned(),
+    }
+}
+
+#[test]
+fn init_logging_reports_global_subscriber_conflict() {
+    init_logging(&logging_config()).expect("first subscriber initialization succeeds");
+
+    let result = init_logging(&logging_config());
+
+    assert!(matches!(
+        result,
+        Err(LoggingInitError::SubscriberInitialization { .. })
+    ));
+}

--- a/authotron/tests/server_integration.rs
+++ b/authotron/tests/server_integration.rs
@@ -53,16 +53,17 @@ services: []
 }
 
 #[tokio::test]
-async fn startup_rejects_port_collision() {
-    let config = Arc::new(base_config(9500, true, 9500));
-    let result = startup::run(config).await;
+async fn startup_rejects_equal_configured_ports_including_zero() {
+    for port in [9500, 0] {
+        let config = Arc::new(base_config(port, true, port));
+        let result = startup::run(config).await;
 
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("must be different"),
-        "expected port collision error, got: {err}"
-    );
+        let error = result.expect_err("equal application and metrics ports must be rejected");
+        assert_eq!(
+            error.to_string(),
+            format!("application port and metrics port are both {port}, they must be different")
+        );
+    }
 }
 
 #[tokio::test]

--- a/authotron/tests/shutdown_integration.rs
+++ b/authotron/tests/shutdown_integration.rs
@@ -1,0 +1,433 @@
+#![cfg(unix)]
+
+use serde_json::Value;
+use std::env;
+use std::fmt::Write as _;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write as _};
+use std::net::{SocketAddr, TcpListener};
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const EVENT_TIMEOUT: Duration = Duration::from_secs(10);
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+struct LogEvent {
+    name: String,
+    attributes: Value,
+}
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn send_sigterm(&self) {
+        // SAFETY: `self.child.id()` is the PID of the live child process owned by this guard.
+        let result = unsafe { libc::kill(self.child.id() as libc::pid_t, libc::SIGTERM) };
+        assert_eq!(result, 0, "failed to send SIGTERM to authotron child");
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+struct SpawnedAuthotron {
+    child: ChildGuard,
+    events: mpsc::Receiver<LogEvent>,
+    output: Arc<Mutex<String>>,
+    readers: Vec<JoinHandle<()>>,
+}
+
+impl SpawnedAuthotron {
+    fn output(&self) -> String {
+        self.output.lock().expect("output lock poisoned").clone()
+    }
+
+    fn wait_for_event(&self, expected_name: &str) -> LogEvent {
+        let deadline = Instant::now() + EVENT_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let event = self.events.recv_timeout(remaining).unwrap_or_else(|error| {
+                panic!(
+                    "did not observe {expected_name:?} ({error})\nchild output:\n{}",
+                    self.output()
+                )
+            });
+            if event.name == expected_name {
+                return event;
+            }
+        }
+    }
+
+    fn join_readers(&mut self) {
+        for reader in self.readers.drain(..) {
+            reader.join().expect("child output reader panicked");
+        }
+    }
+}
+
+struct ConfigFile(PathBuf);
+
+impl Drop for ConfigFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+struct DelayedUpstream {
+    address: SocketAddr,
+    request_started: mpsc::Receiver<()>,
+    release_response: Option<mpsc::Sender<()>>,
+    server: Option<JoinHandle<Result<(), String>>>,
+}
+
+impl DelayedUpstream {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind delayed upstream");
+        let address = listener
+            .local_addr()
+            .expect("read delayed upstream address");
+        let (request_started_tx, request_started) = mpsc::channel();
+        let (release_response, release_response_rx) = mpsc::channel();
+
+        let server = thread::spawn(move || {
+            listener
+                .set_nonblocking(true)
+                .map_err(|error| error.to_string())?;
+            let deadline = Instant::now() + EVENT_TIMEOUT;
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(connection) => break connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return Err("timed out waiting for delayed upstream request".to_owned());
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => return Err(error.to_string()),
+                }
+            };
+
+            stream
+                .set_read_timeout(Some(EVENT_TIMEOUT))
+                .map_err(|error| error.to_string())?;
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream
+                    .read(&mut buffer)
+                    .map_err(|error| error.to_string())?;
+                if read == 0 {
+                    return Err("upstream client closed before sending headers".to_owned());
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if request.len() > 64 * 1024 {
+                    return Err("upstream request headers were unexpectedly large".to_owned());
+                }
+            }
+
+            let request = String::from_utf8_lossy(&request);
+            if !request.starts_with("GET /who-am-i?token=slow-token ") {
+                return Err(format!("unexpected upstream request: {request}"));
+            }
+            request_started_tx
+                .send(())
+                .map_err(|error| error.to_string())?;
+            release_response_rx
+                .recv_timeout(EVENT_TIMEOUT)
+                .map_err(|error| error.to_string())?;
+
+            let body = r#"{"uid":"graceful-user","email":"graceful@example.test"}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .map_err(|error| error.to_string())?;
+            stream.flush().map_err(|error| error.to_string())?;
+            Ok(())
+        });
+
+        Self {
+            address,
+            request_started,
+            release_response: Some(release_response),
+            server: Some(server),
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("http://{}", self.address)
+    }
+
+    fn wait_until_requested(&self) {
+        self.request_started
+            .recv_timeout(EVENT_TIMEOUT)
+            .expect("authotron did not start the delayed upstream request");
+    }
+
+    fn release(&mut self) {
+        self.release_response
+            .take()
+            .expect("delayed response already released")
+            .send(())
+            .expect("delayed upstream stopped before release");
+    }
+
+    fn finish(mut self) {
+        self.server
+            .take()
+            .expect("delayed upstream thread missing")
+            .join()
+            .expect("delayed upstream panicked")
+            .expect("delayed upstream failed");
+    }
+}
+
+fn write_config(upstream_url: &str, metrics_enabled: bool) -> ConfigFile {
+    let mode = if metrics_enabled {
+        "metrics-enabled"
+    } else {
+        "metrics-disabled"
+    };
+    let path = env::temp_dir().join(format!(
+        "authotron-shutdown-{}-{mode}.yaml",
+        std::process::id()
+    ));
+    let config = format!(
+        r#"version: "2.0.0"
+logging:
+  level: "info"
+  format: "json"
+auth:
+  timeout_in_ms: 10000
+providers:
+  - name: "Delayed ECMWF API"
+    type: "ecmwf-api"
+    uri: "{upstream_url}"
+    realm: "ecmwf"
+augmenters: []
+store:
+  enabled: false
+services: []
+jwt:
+  exp: 3600
+  iss: "authotron-shutdown-test"
+  secret: "test-secret"
+server:
+  host: "127.0.0.1"
+  port: 0
+metrics:
+  enabled: {metrics_enabled}
+  port: 0
+"#
+    );
+    fs::write(&path, config).expect("write authotron test config");
+    ConfigFile(path)
+}
+
+fn spawn_output_reader(
+    reader: impl Read + Send + 'static,
+    stream_name: &'static str,
+    events: mpsc::Sender<LogEvent>,
+    output: Arc<Mutex<String>>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        for line in BufReader::new(reader).lines() {
+            let line = line.expect("read authotron child output");
+            {
+                let mut output = output.lock().expect("output lock poisoned");
+                writeln!(output, "[{stream_name}] {line}").expect("append child output");
+            }
+            let Ok(record) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            let Some(name) = record
+                .pointer("/attributes/event.name")
+                .and_then(Value::as_str)
+            else {
+                continue;
+            };
+            let _ = events.send(LogEvent {
+                name: name.to_owned(),
+                attributes: record["attributes"].clone(),
+            });
+        }
+    })
+}
+
+fn spawn_authotron(config_path: &PathBuf) -> SpawnedAuthotron {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_authotron"));
+    for (key, _) in env::vars_os() {
+        if key.to_string_lossy().starts_with("AOT_") {
+            command.env_remove(key);
+        }
+    }
+    for key in [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ] {
+        command.env_remove(key);
+    }
+    let mut child = command
+        .env("AOT_CONFIG_PATH", config_path)
+        .env("NO_PROXY", "127.0.0.1,localhost")
+        .env("no_proxy", "127.0.0.1,localhost")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn authotron binary");
+
+    let stdout = child.stdout.take().expect("capture authotron stdout");
+    let stderr = child.stderr.take().expect("capture authotron stderr");
+    let output = Arc::new(Mutex::new(String::new()));
+    let (events_tx, events) = mpsc::channel();
+    let readers = vec![
+        spawn_output_reader(stdout, "stdout", events_tx.clone(), output.clone()),
+        spawn_output_reader(stderr, "stderr", events_tx, output.clone()),
+    ];
+
+    SpawnedAuthotron {
+        child: ChildGuard { child },
+        events,
+        output,
+        readers,
+    }
+}
+
+fn event_port(event: &LogEvent) -> u16 {
+    event.attributes["port"]
+        .as_u64()
+        .and_then(|port| u16::try_from(port).ok())
+        .filter(|port| *port != 0)
+        .unwrap_or_else(|| panic!("event did not contain a bound port: {event:?}"))
+}
+
+async fn wait_for_exit(child: &mut Child) -> ExitStatus {
+    let deadline = Instant::now() + PROCESS_TIMEOUT;
+    loop {
+        if let Some(status) = child.try_wait().expect("poll authotron child") {
+            return status;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "authotron did not exit after completing its in-flight request"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn run_shutdown_case(metrics_enabled: bool) {
+    let mut upstream = DelayedUpstream::start();
+    let config = write_config(&upstream.url(), metrics_enabled);
+    let mut authotron = spawn_authotron(&config.0);
+
+    let app_port = event_port(&authotron.wait_for_event("startup.server.listening"));
+    let metrics_port = if metrics_enabled {
+        Some(event_port(
+            &authotron.wait_for_event("startup.metrics.listening"),
+        ))
+    } else {
+        authotron.wait_for_event("startup.metrics.disabled");
+        None
+    };
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .timeout(EVENT_TIMEOUT)
+        .build()
+        .expect("build HTTP test client");
+    let app_health = client
+        .get(format!("http://127.0.0.1:{app_port}/health"))
+        .send()
+        .await
+        .expect("request application health endpoint");
+    assert_eq!(app_health.status(), reqwest::StatusCode::OK);
+
+    if let Some(metrics_port) = metrics_port {
+        let metrics = client
+            .get(format!("http://127.0.0.1:{metrics_port}/metrics"))
+            .send()
+            .await
+            .expect("request metrics endpoint");
+        assert_eq!(metrics.status(), reqwest::StatusCode::OK);
+        assert!(
+            metrics
+                .text()
+                .await
+                .expect("read metrics response")
+                .contains("authotron_http_requests_total"),
+            "metrics endpoint should expose authotron metrics"
+        );
+    }
+
+    let delayed_client = client.clone();
+    let delayed_request = tokio::spawn(async move {
+        let response = delayed_client
+            .get(format!("http://127.0.0.1:{app_port}/authenticate"))
+            .bearer_auth("slow-token")
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.text().await?;
+        Ok::<_, reqwest::Error>((status, body))
+    });
+    upstream.wait_until_requested();
+
+    authotron.child.send_sigterm();
+    let shutdown = authotron.wait_for_event("startup.shutdown.requested");
+    assert_eq!(shutdown.attributes["signal"], "SIGTERM");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        authotron
+            .child
+            .child
+            .try_wait()
+            .expect("poll draining authotron child")
+            .is_none(),
+        "authotron exited before its in-flight request completed\n{}",
+        authotron.output()
+    );
+
+    upstream.release();
+    let (status, body) = tokio::time::timeout(PROCESS_TIMEOUT, delayed_request)
+        .await
+        .expect("in-flight request did not finish after upstream release")
+        .expect("in-flight request task panicked")
+        .expect("in-flight request failed");
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body, "Authenticated successfully");
+
+    let status = wait_for_exit(&mut authotron.child.child).await;
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "authotron did not exit successfully\n{}",
+        authotron.output()
+    );
+    authotron.join_readers();
+    upstream.finish();
+}
+
+// Keep both process-and-signal scenarios in one test so the harness cannot run them concurrently.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sigterm_drains_in_flight_request_and_exits_zero_with_and_without_metrics() {
+    run_shutdown_case(true).await;
+    run_shutdown_case(false).await;
+}

--- a/authotron/tests/shutdown_integration.rs
+++ b/authotron/tests/shutdown_integration.rs
@@ -4,8 +4,10 @@ use serde_json::Value;
 use std::env;
 use std::fmt::Write as _;
 use std::fs;
-use std::io::{BufRead, BufReader, Read, Write as _};
+use std::io::{self, BufRead, BufReader, Read, Write as _};
 use std::net::{SocketAddr, TcpListener};
+use std::os::fd::AsRawFd;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::{Arc, Mutex, mpsc};
@@ -14,6 +16,9 @@ use std::time::{Duration, Instant};
 
 const EVENT_TIMEOUT: Duration = Duration::from_secs(10);
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
+const APP_LISTENER_FD: libc::c_int = 100;
+const METRICS_LISTENER_FD: libc::c_int = 101;
+const TEMPORARY_FD_START: libc::c_int = 102;
 
 #[derive(Debug)]
 struct LogEvent {
@@ -82,6 +87,53 @@ struct ConfigFile(PathBuf);
 impl Drop for ConfigFile {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.0);
+    }
+}
+
+struct PreboundListeners {
+    app: TcpListener,
+    metrics: Option<TcpListener>,
+}
+
+impl PreboundListeners {
+    fn bind(metrics_enabled: bool) -> Self {
+        let app = TcpListener::bind("127.0.0.1:0").expect("pre-bind application listener");
+        let metrics = metrics_enabled
+            .then(|| TcpListener::bind("127.0.0.1:0").expect("pre-bind metrics listener"));
+
+        if let Some(metrics) = &metrics {
+            assert_ne!(
+                app.local_addr()
+                    .expect("application listener address")
+                    .port(),
+                metrics
+                    .local_addr()
+                    .expect("metrics listener address")
+                    .port(),
+                "pre-bound listeners must use distinct ports"
+            );
+        }
+
+        Self { app, metrics }
+    }
+
+    fn app_port(&self) -> u16 {
+        self.app
+            .local_addr()
+            .expect("application listener address")
+            .port()
+    }
+
+    fn metrics_port(&self) -> u16 {
+        self.metrics
+            .as_ref()
+            .map(|listener| {
+                listener
+                    .local_addr()
+                    .expect("metrics listener address")
+                    .port()
+            })
+            .unwrap_or(0)
     }
 }
 
@@ -195,7 +247,11 @@ impl DelayedUpstream {
     }
 }
 
-fn write_config(upstream_url: &str, metrics_enabled: bool) -> ConfigFile {
+fn write_config(
+    upstream_url: &str,
+    metrics_enabled: bool,
+    listeners: &PreboundListeners,
+) -> ConfigFile {
     let mode = if metrics_enabled {
         "metrics-enabled"
     } else {
@@ -205,6 +261,8 @@ fn write_config(upstream_url: &str, metrics_enabled: bool) -> ConfigFile {
         "authotron-shutdown-{}-{mode}.yaml",
         std::process::id()
     ));
+    let app_port = listeners.app_port();
+    let metrics_port = listeners.metrics_port();
     let config = format!(
         r#"version: "2.0.0"
 logging:
@@ -227,10 +285,10 @@ jwt:
   secret: "test-secret"
 server:
   host: "127.0.0.1"
-  port: 0
+  port: {app_port}
 metrics:
   enabled: {metrics_enabled}
-  port: 0
+  port: {metrics_port}
 "#
     );
     fs::write(&path, config).expect("write authotron test config");
@@ -267,7 +325,59 @@ fn spawn_output_reader(
     })
 }
 
-fn spawn_authotron(config_path: &PathBuf) -> SpawnedAuthotron {
+fn duplicate_inherited_listener(source: libc::c_int) -> io::Result<libc::c_int> {
+    // SAFETY: `fcntl` only operates on an integer file descriptor. On success, this
+    // returns a new descriptor owned by the child process.
+    let temporary = unsafe { libc::fcntl(source, libc::F_DUPFD_CLOEXEC, TEMPORARY_FD_START) };
+    if temporary == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(temporary)
+    }
+}
+
+fn install_duplicated_listener(temporary: libc::c_int, target: libc::c_int) -> io::Result<()> {
+    // SAFETY: `temporary` is a valid descriptor returned by `fcntl`.
+    let result = unsafe { libc::dup2(temporary, target) };
+    let error = (result == -1).then(io::Error::last_os_error);
+    // SAFETY: this function takes ownership of the temporary descriptor.
+    unsafe { libc::close(temporary) };
+    error.map_or(Ok(()), Err)
+}
+
+fn install_inherited_listeners(
+    app_source: libc::c_int,
+    metrics_source: Option<libc::c_int>,
+) -> io::Result<()> {
+    // Duplicate every source above the fixed target range before overwriting either
+    // target, so this remains correct even if a source descriptor equals a target.
+    let app = duplicate_inherited_listener(app_source)?;
+    let metrics = match metrics_source.map(duplicate_inherited_listener).transpose() {
+        Ok(metrics) => metrics,
+        Err(error) => {
+            // SAFETY: `app` is owned by this function and has not been installed.
+            unsafe { libc::close(app) };
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = install_duplicated_listener(app, APP_LISTENER_FD) {
+        if let Some(metrics) = metrics {
+            // SAFETY: `metrics` is owned by this function and has not been installed.
+            unsafe { libc::close(metrics) };
+        }
+        return Err(error);
+    }
+    if let Some(metrics) = metrics {
+        install_duplicated_listener(metrics, METRICS_LISTENER_FD)?;
+    }
+
+    Ok(())
+}
+
+fn spawn_authotron(config_path: &PathBuf, listeners: PreboundListeners) -> SpawnedAuthotron {
+    let app_listener_fd = listeners.app.as_raw_fd();
+    let metrics_listener_fd = listeners.metrics.as_ref().map(AsRawFd::as_raw_fd);
     let mut command = Command::new(env!("CARGO_BIN_EXE_authotron"));
     for (key, _) in env::vars_os() {
         if key.to_string_lossy().starts_with("AOT_") {
@@ -284,15 +394,32 @@ fn spawn_authotron(config_path: &PathBuf) -> SpawnedAuthotron {
     ] {
         command.env_remove(key);
     }
-    let mut child = command
+    command
         .env("AOT_CONFIG_PATH", config_path)
+        .env(
+            "AUTHOTRON_TEST_APP_LISTENER_FD",
+            APP_LISTENER_FD.to_string(),
+        )
         .env("NO_PROXY", "127.0.0.1,localhost")
         .env("no_proxy", "127.0.0.1,localhost")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn authotron binary");
+        .stderr(Stdio::piped());
+    if metrics_listener_fd.is_some() {
+        command.env(
+            "AUTHOTRON_TEST_METRICS_LISTENER_FD",
+            METRICS_LISTENER_FD.to_string(),
+        );
+    }
+
+    // SAFETY: the closure only invokes async-signal-safe descriptor syscalls between
+    // `fork` and `exec`. The source listeners remain alive until `spawn` returns.
+    unsafe {
+        command.pre_exec(move || install_inherited_listeners(app_listener_fd, metrics_listener_fd));
+    }
+
+    let mut child = command.spawn().expect("spawn authotron binary");
+    drop(listeners);
 
     let stdout = child.stdout.take().expect("capture authotron stdout");
     let stderr = child.stderr.take().expect("capture authotron stderr");
@@ -335,9 +462,9 @@ async fn wait_for_exit(child: &mut Child) -> ExitStatus {
 
 async fn run_shutdown_case(metrics_enabled: bool) {
     let mut upstream = DelayedUpstream::start();
-    let config = write_config(&upstream.url(), metrics_enabled);
-    let mut authotron = spawn_authotron(&config.0);
-
+    let listeners = PreboundListeners::bind(metrics_enabled);
+    let config = write_config(&upstream.url(), metrics_enabled, &listeners);
+    let mut authotron = spawn_authotron(&config.0, listeners);
     let app_port = event_port(&authotron.wait_for_event("startup.server.listening"));
     let metrics_port = if metrics_enabled {
         Some(event_port(


### PR DESCRIPTION
Changelog:
- Gracefully drain the application and metrics servers on SIGINT/SIGTERM through one shutdown coordinator.
- Add Unix black-box coverage using the real binary, OS-assigned app/metrics ports, and a delayed upstream request; verify SIGTERM drains the request and exits 0 with metrics enabled and disabled.
- Cache version-expanded homepage HTML with `LazyLock<String>`.
- Return typed logging initialization errors and report startup failures without panicking.
- Document shutdown and logging startup behavior.

Tests:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo build --release --workspace`
- `mdbook build authotron/docs`

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-83
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->