### PR TITLE
Add Argon2id passwords to the plain provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +130,7 @@ name = "authotron"
 version = "0.3.7"
 dependencies = [
  "aide",
+ "argon2",
  "async-trait",
  "authotron-types",
  "axum",
@@ -136,6 +149,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "subtle",
  "tokio",
  "tower",
  "tracing",
@@ -283,6 +297,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -2263,6 +2286,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sha2",
  "subtle",
  "tokio",
  "tower",

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -33,6 +33,7 @@ base64 = "~0.22"
 jsonwebtoken = { version = "~10.3", features = ["rust_crypto"] }
 argon2 = "~0.5"
 subtle = "~2.6"
+sha2 = "~0.10"
 ldap3 = "~0.12"
 
 # Data & serialization

--- a/authotron/Cargo.toml
+++ b/authotron/Cargo.toml
@@ -31,6 +31,8 @@ tokio = { version = "~1.50", features = ["full"] }
 # Authentication & crypto
 base64 = "~0.22"
 jsonwebtoken = { version = "~10.3", features = ["rust_crypto"] }
+argon2 = "~0.5"
+subtle = "~2.6"
 ldap3 = "~0.12"
 
 # Data & serialization

--- a/authotron/docs/src/configuration/README.md
+++ b/authotron/docs/src/configuration/README.md
@@ -63,10 +63,12 @@ providers:
     realm: internal
     users:
       - username: admin
-        password: adminpass
+        # Hash of adminpass for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wMg$z1Q74VCoGWdQC7OycwP1XrHF5mtr3GnxX68PUqEe0PQ"
         roles: [admin, user]
       - username: guest
-        password: guestpass
+        # Hash of guestpass for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wMw$4EYE6u9AV7M5q2hnrIurr2Ws8jvJuNaM+W4ki331HsQ"
         roles: [readonly]
 
   - type: jwt

--- a/authotron/docs/src/configuration/providers.md
+++ b/authotron/docs/src/configuration/providers.md
@@ -16,18 +16,21 @@ All providers share these common fields:
 
 Type: `plain`
 
-The plain provider implements HTTP Basic Authentication against a static list of users defined in the configuration file. This is useful for development, testing, or simple deployments.
+The plain provider implements HTTP Basic Authentication against a static list of users defined in the configuration file. Store passwords as Argon2id hashes in PHC string format.
 
 **Fields:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| users | array | List of user objects with username, password, and roles |
+| users | array | List of user objects with username, password credential, and roles |
 
 Each user object has:
 - `username`: The login name
-- `password`: The password (compared as plaintext)
+- `password_hash`: An Argon2id PHC string (recommended)
+- `password`: Deprecated plaintext compatibility; do not use for new configurations
 - `roles`: Array of role strings assigned to the user (optional, defaults to empty)
+
+Each user must contain exactly one of `password_hash` or `password`. Generate hashes with an Argon2id implementation using a unique random salt and parameters appropriate for your deployment.
 
 **Example:**
 
@@ -38,10 +41,12 @@ providers:
     realm: internal
     users:
       - username: alice
-        password: alicepass123
+        # Hash of alicepass123 for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wNQ$bnM0TZfPrwI0Eb2pfBCK39sjwVCHBBUZYykFUnbwWfw"
         roles: [admin, developer]
       - username: bob
-        password: bobpass456
+        # Hash of bobpass456 for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wNg$yVm3rzolxmoIYoxZyU/TR7q/PYcU73TsTxUdmXxyIRA"
         roles: [developer]
 ```
 
@@ -194,7 +199,8 @@ providers:
     realm: development
     users:
       - username: dev
-        password: devpass
+        # Hash of devpass for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wNw$T21rHRps148bp1VTW3bEfiri1l28TUS9CL9WUL6Xll0"
         roles: [admin]
 
   - type: jwt

--- a/authotron/docs/src/configuration/providers.md
+++ b/authotron/docs/src/configuration/providers.md
@@ -32,6 +32,10 @@ Each user object has:
 
 Each user must contain exactly one of `password_hash` or `password`. Generate hashes with an Argon2id implementation using a unique random salt and parameters appropriate for your deployment.
 
+Argon2 verification is globally limited to at most two concurrent jobs (and no more than the available CPU parallelism). Excess attempts wait within the normal authentication timeout; work already running remains counted until its blocking operation finishes.
+
+Every well-formed Basic authentication attempt performs one Argon2id verification. Unknown usernames and deprecated plaintext entries use a fixed dummy hash with the example/default parameters (`m=19456,t=2,p=1`); plaintext passwords are then checked via constant-time comparison of fixed-size SHA-256 digests. Plaintext remains a migration-only compatibility path. Use consistent Argon2id parameters for all configured hashes, because deliberately different PHC cost parameters necessarily have different runtimes.
+
 **Example:**
 
 ```yaml

--- a/authotron/docs/src/deployment/kubernetes.md
+++ b/authotron/docs/src/deployment/kubernetes.md
@@ -125,5 +125,6 @@ config:
       realm: default
       users:
         - username: admin
-          password: changeme
+          # Hash of changeme for this example only; replace before deployment.
+          password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wNA$kqv1lupkwH+Kg9ogq2mlMH8rdj9aPMGQ3bBhLbqswUU"
 ```

--- a/authotron/docs/src/getting-started/quickstart.md
+++ b/authotron/docs/src/getting-started/quickstart.md
@@ -15,7 +15,8 @@ providers:
     realm: "default"
     users:
       - username: "test_user"
-        password: "secret123"
+        # Hash of secret123 for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wMA$nIbsJAh7Dy4U3lp30gdyZp5xIvGEixDw6egf5H1ckpQ"
 
 augmenters: []
 
@@ -40,6 +41,8 @@ server:
 metrics:
   enabled: false
 ```
+
+The example credentials are `test_user:secret123`. Generate a new Argon2id hash with a unique random salt before using the configuration outside this quick start.
 
 ## Run the Server
 

--- a/authotron/examples/nginx-auth/config/auth-o-tron.yml
+++ b/authotron/examples/nginx-auth/config/auth-o-tron.yml
@@ -13,9 +13,11 @@ providers:
     realm: "localrealm"
     users:
       - username: "test_user"
-        password: "secret123"
+        # Hash of secret123 for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wMA$nIbsJAh7Dy4U3lp30gdyZp5xIvGEixDw6egf5H1ckpQ"
       - username: "test_user2"
-        password: "p@ssw0rd"
+        # Hash of p@ssw0rd for this example only.
+        password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wMQ$9SHjr4wGPrTaxgJJ+ELNof/S/JXH7gN6LYGAwVo4qL4"
   - name: "ECMWF API Provider"
     type: "ecmwf-api"
     uri: https://api.ecmwf.int/v1

--- a/authotron/schema.json
+++ b/authotron/schema.json
@@ -312,14 +312,20 @@
       ]
     },
     "PlainUserEntry": {
-      "description": "Represents a single user entry (username + password).",
+      "description": "A plain-provider user with exactly one password credential.",
       "type": "object",
       "properties": {
         "username": {
           "type": "string"
         },
-        "password": {
+        "password_hash": {
+          "description": "An Argon2id hash in PHC string format (recommended).",
           "type": "string"
+        },
+        "password": {
+          "description": "Deprecated plaintext password. Use password_hash instead.",
+          "type": "string",
+          "deprecated": true
         },
         "roles": {
           "type": [
@@ -332,9 +338,21 @@
         }
       },
       "required": [
-        "username",
-        "password"
-      ]
+        "username"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "password_hash"
+          ]
+        },
+        {
+          "required": [
+            "password"
+          ]
+        }
+      ],
+      "additionalProperties": false
     },
     "PlainAuthConfig": {
       "description": "PlainAuthConfig defines the data for Basic authentication.",
@@ -349,7 +367,7 @@
           "type": "string"
         },
         "users": {
-          "description": "A list of username/password pairs.",
+          "description": "A list of users and their password credentials.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/PlainUserEntry"
@@ -593,7 +611,7 @@
         },
         "service_version": {
           "type": "string",
-          "default": "0.2.12"
+          "default": "0.3.7"
         }
       },
       "required": [

--- a/authotron/src/providers/plain_provider.rs
+++ b/authotron/src/providers/plain_provider.rs
@@ -6,11 +6,15 @@
 // granted to it by virtue of its status as an intergovernmental organisation nor
 // does it submit to any jurisdiction.
 
+use std::{borrow::Cow, fmt};
+
+use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use subtle::ConstantTimeEq;
+use tracing::{debug, warn};
 
 use crate::models::user::User;
 use crate::providers::Provider;
@@ -22,16 +26,116 @@ pub struct PlainAuthConfig {
     pub name: String,
     /// The realm associated with this provider.
     pub realm: String,
-    /// A list of username/password pairs.
+    /// A list of users and their password credentials.
     pub users: Vec<PlainUserEntry>,
 }
 
-/// Represents a single user entry (username + password).
-#[derive(Deserialize, Serialize, Debug, JsonSchema, Clone)]
+/// Represents a single user entry and its password credential.
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct PlainUserEntry {
     pub username: String,
-    pub password: String,
+    /// Exactly one Argon2id hash or deprecated plaintext password.
+    #[serde(flatten)]
+    pub credential: PlainCredential,
     pub roles: Option<Vec<String>>,
+}
+
+impl JsonSchema for PlainUserEntry {
+    fn schema_name() -> Cow<'static, str> {
+        "PlainUserEntry".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "description": "A plain-provider user with exactly one password credential.",
+            "type": "object",
+            "properties": {
+                "username": { "type": "string" },
+                "password_hash": {
+                    "description": "An Argon2id hash in PHC string format (recommended).",
+                    "type": "string"
+                },
+                "password": {
+                    "description": "Deprecated plaintext password. Use password_hash instead.",
+                    "type": "string",
+                    "deprecated": true
+                },
+                "roles": {
+                    "type": ["array", "null"],
+                    "items": { "type": "string" }
+                }
+            },
+            "required": ["username"],
+            "oneOf": [
+                { "required": ["password_hash"] },
+                { "required": ["password"] }
+            ],
+            "additionalProperties": false
+        })
+    }
+}
+
+/// Password configuration for a plain-provider user.
+#[derive(Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(untagged)]
+pub enum PlainCredential {
+    /// Preferred Argon2id PHC string.
+    Argon2id(Argon2idCredential),
+    /// Deprecated plaintext compatibility.
+    Plaintext(PlaintextCredential),
+}
+
+#[derive(Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct Argon2idCredential {
+    /// An Argon2id hash in PHC string format.
+    pub password_hash: String,
+}
+
+#[derive(Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct PlaintextCredential {
+    /// Deprecated: plaintext password. Use `password_hash` instead.
+    pub password: String,
+}
+
+impl fmt::Debug for PlainCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PlainCredential([REDACTED])")
+    }
+}
+
+impl PlainCredential {
+    async fn verify(&self, candidate: &str) -> bool {
+        match self {
+            Self::Argon2id(credential) => {
+                let password_hash = credential.password_hash.clone();
+                let candidate = candidate.as_bytes().to_vec();
+                tokio::task::spawn_blocking(move || verify_argon2id(&password_hash, &candidate))
+                    .await
+                    .unwrap_or(false)
+            }
+            Self::Plaintext(credential) => credential
+                .password
+                .as_bytes()
+                .ct_eq(candidate.as_bytes())
+                .into(),
+        }
+    }
+}
+
+fn verify_argon2id(password_hash: &str, candidate: &[u8]) -> bool {
+    let Ok(parsed_hash) = PasswordHash::new(password_hash) else {
+        return false;
+    };
+
+    if parsed_hash.algorithm.as_str() != "argon2id" {
+        return false;
+    }
+
+    Argon2::default()
+        .verify_password(candidate, &parsed_hash)
+        .is_ok()
 }
 
 /// A `PlainAuthProvider` that implements Basic authentication by
@@ -43,6 +147,20 @@ pub struct PlainAuthProvider {
 impl PlainAuthProvider {
     /// Create a new `PlainAuthProvider` from the config struct.
     pub fn new(config: &PlainAuthConfig) -> Self {
+        if config
+            .users
+            .iter()
+            .any(|entry| matches!(&entry.credential, PlainCredential::Plaintext(_)))
+        {
+            warn!(
+                event_name = "providers.plain.plaintext_password.deprecated",
+                event_domain = "providers",
+                provider_name = config.name.as_str(),
+                realm = config.realm.as_str(),
+                "plain provider uses deprecated plaintext passwords; use Argon2id password_hash entries"
+            );
+        }
+
         Self {
             config: config.clone(),
         }
@@ -116,14 +234,13 @@ impl Provider for PlainAuthProvider {
             "basic authentication attempt"
         );
         for entry in &self.config.users {
-            if entry.username == user_part && entry.password == pass_part {
-                // Found a match! Return a new user object.
+            if entry.username == user_part && entry.credential.verify(pass_part).await {
                 return Ok(User::new(
                     self.config.realm.clone(),
                     user_part.to_string(),
-                    entry.roles.clone(), // roles
-                    None,                // attributes
-                    None,                // scopes
+                    entry.roles.clone(),
+                    None,
+                    None,
                     Some(1),
                 ));
             }
@@ -136,7 +253,25 @@ impl Provider for PlainAuthProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use argon2::{Algorithm, Params, PasswordHasher, Version, password_hash::SaltString};
     use base64::engine::general_purpose;
+
+    fn plaintext(password: &str) -> PlainCredential {
+        PlainCredential::Plaintext(PlaintextCredential {
+            password: password.to_string(),
+        })
+    }
+
+    fn argon2id(password: &str) -> PlainCredential {
+        let params = Params::new(1024, 1, 1, None).expect("valid test Argon2 parameters");
+        let hasher = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+        let salt = SaltString::encode_b64(b"authotron-tests!").expect("valid test salt");
+        let password_hash = hasher
+            .hash_password(password.as_bytes(), &salt)
+            .expect("test password should hash")
+            .to_string();
+        PlainCredential::Argon2id(Argon2idCredential { password_hash })
+    }
 
     fn create_test_config() -> PlainAuthConfig {
         PlainAuthConfig {
@@ -145,22 +280,22 @@ mod tests {
             users: vec![
                 PlainUserEntry {
                     username: "admin".to_string(),
-                    password: "admin123".to_string(),
+                    credential: plaintext("admin123"),
                     roles: Some(vec!["admin".to_string(), "user".to_string()]),
                 },
                 PlainUserEntry {
                     username: "user1".to_string(),
-                    password: "password1".to_string(),
+                    credential: plaintext("password1"),
                     roles: Some(vec!["user".to_string()]),
                 },
                 PlainUserEntry {
                     username: "guest".to_string(),
-                    password: "guest123".to_string(),
+                    credential: plaintext("guest123"),
                     roles: None, // No roles
                 },
                 PlainUserEntry {
                     username: "empty_roles".to_string(),
-                    password: "password".to_string(),
+                    credential: plaintext("password"),
                     roles: Some(vec![]), // Empty roles vector
                 },
             ],
@@ -173,7 +308,7 @@ mod tests {
             realm: "test".to_string(),
             users: vec![PlainUserEntry {
                 username: "user@domain.com".to_string(),
-                password: "p@ssw0rd!#$".to_string(),
+                credential: plaintext("p@ssw0rd!#$"),
                 roles: Some(vec!["special".to_string()]),
             }],
         }
@@ -185,7 +320,7 @@ mod tests {
             realm: "test".to_string(),
             users: vec![PlainUserEntry {
                 username: "用户".to_string(),
-                password: "密码".to_string(),
+                credential: plaintext("密码"),
                 roles: Some(vec!["unicode".to_string()]),
             }],
         }
@@ -511,5 +646,109 @@ mod tests {
         assert_eq!(provider.config.name, "TestPlain");
         assert_eq!(provider.config.realm, "test");
         assert_eq!(provider.config.users.len(), 4);
+    }
+    #[tokio::test]
+    async fn test_authenticate_correct_argon2id_hash() {
+        let provider = PlainAuthProvider::new(&PlainAuthConfig {
+            name: "Hashed".to_string(),
+            realm: "test".to_string(),
+            users: vec![PlainUserEntry {
+                username: "hashed-user".to_string(),
+                credential: argon2id("correct horse battery staple"),
+                roles: Some(vec!["user".to_string()]),
+            }],
+        });
+        let credentials =
+            general_purpose::STANDARD.encode("hashed-user:correct horse battery staple");
+
+        let user = provider
+            .authenticate(&credentials)
+            .await
+            .expect("correct password should authenticate");
+
+        assert_eq!(user.username, "hashed-user");
+        assert_eq!(user.roles, vec!["user"]);
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_incorrect_argon2id_password() {
+        let provider = PlainAuthProvider::new(&PlainAuthConfig {
+            name: "Hashed".to_string(),
+            realm: "test".to_string(),
+            users: vec![PlainUserEntry {
+                username: "hashed-user".to_string(),
+                credential: argon2id("right-password"),
+                roles: None,
+            }],
+        });
+        let credentials = general_purpose::STANDARD.encode("hashed-user:wrong-password");
+
+        let result = provider.authenticate(&credentials).await;
+
+        assert_eq!(result.unwrap_err(), "Wrong username or password");
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_malformed_argon2id_hash() {
+        let provider = PlainAuthProvider::new(&PlainAuthConfig {
+            name: "Hashed".to_string(),
+            realm: "test".to_string(),
+            users: vec![PlainUserEntry {
+                username: "hashed-user".to_string(),
+                credential: PlainCredential::Argon2id(Argon2idCredential {
+                    password_hash: "$argon2id$malformed".to_string(),
+                }),
+                roles: None,
+            }],
+        });
+        let credentials = general_purpose::STANDARD.encode("hashed-user:any-password");
+
+        let result = provider.authenticate(&credentials).await;
+
+        assert_eq!(result.unwrap_err(), "Wrong username or password");
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_unicode_argon2id_password() {
+        let provider = PlainAuthProvider::new(&PlainAuthConfig {
+            name: "Hashed".to_string(),
+            realm: "test".to_string(),
+            users: vec![PlainUserEntry {
+                username: "unicode-user".to_string(),
+                credential: argon2id("密码🔐"),
+                roles: None,
+            }],
+        });
+        let credentials = general_purpose::STANDARD.encode("unicode-user:密码🔐");
+
+        let result = provider.authenticate(&credentials).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_plaintext_credential_deserializes_for_compatibility() {
+        let entry: PlainUserEntry = serde_json::from_str(
+            r#"{"username":"legacy","password":"still-supported","roles":[]}"#,
+        )
+        .expect("deprecated plaintext credential should remain supported");
+
+        assert!(matches!(entry.credential, PlainCredential::Plaintext(_)));
+    }
+
+    #[test]
+    fn test_credential_rejects_hash_and_plaintext() {
+        let result = serde_json::from_str::<PlainUserEntry>(
+            r#"{"username":"ambiguous","password_hash":"$argon2id$...","password":"secret"}"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_credential_rejects_missing_hash_and_plaintext() {
+        let result = serde_json::from_str::<PlainUserEntry>(r#"{"username":"missing"}"#);
+
+        assert!(result.is_err());
     }
 }

--- a/authotron/src/providers/plain_provider.rs
+++ b/authotron/src/providers/plain_provider.rs
@@ -6,14 +6,20 @@
 // granted to it by virtue of its status as an intergovernmental organisation nor
 // does it submit to any jurisdiction.
 
-use std::{borrow::Cow, fmt};
+use std::{
+    borrow::Cow,
+    fmt,
+    sync::{Arc, OnceLock},
+};
 
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
 use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
+use tokio::sync::Semaphore;
 use tracing::{debug, warn};
 
 use crate::models::user::User;
@@ -105,48 +111,136 @@ impl fmt::Debug for PlainCredential {
     }
 }
 
-impl PlainCredential {
-    async fn verify(&self, candidate: &str) -> bool {
-        match self {
-            Self::Argon2id(credential) => {
-                let password_hash = credential.password_hash.clone();
-                let candidate = candidate.as_bytes().to_vec();
-                tokio::task::spawn_blocking(move || verify_argon2id(&password_hash, &candidate))
-                    .await
-                    .unwrap_or(false)
-            }
-            Self::Plaintext(credential) => credential
-                .password
-                .as_bytes()
-                .ct_eq(candidate.as_bytes())
-                .into(),
+const MAX_CONCURRENT_ARGON2_JOBS: usize = 2;
+const DUMMY_ARGON2ID_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wMA$nIbsJAh7Dy4U3lp30gdyZp5xIvGEixDw6egf5H1ckpQ";
+const DUMMY_PLAINTEXT: &[u8] = b"authotron-dummy-plaintext-password";
+
+type Argon2Verification = dyn Fn(&str, &[u8]) -> bool + Send + Sync;
+
+struct BoundedArgon2Verifier {
+    permits: Arc<Semaphore>,
+    verification: Arc<Argon2Verification>,
+}
+
+impl BoundedArgon2Verifier {
+    fn new<F>(concurrency: usize, verification: F) -> Self
+    where
+        F: Fn(&str, &[u8]) -> bool + Send + Sync + 'static,
+    {
+        Self {
+            permits: Arc::new(Semaphore::new(concurrency.max(1))),
+            verification: Arc::new(verification),
         }
+    }
+
+    async fn verify(&self, password_hash: &str, candidate: &[u8]) -> bool {
+        let Ok(permit) = self.permits.clone().acquire_owned().await else {
+            return false;
+        };
+        let password_hash = password_hash.to_owned();
+        let candidate = candidate.to_vec();
+        let verification = Arc::clone(&self.verification);
+
+        tokio::task::spawn_blocking(move || {
+            // The blocking closure owns the permit so cancellation or request timeout
+            // cannot release capacity while Argon2 work is still running.
+            let _permit = permit;
+            verification(&password_hash, &candidate)
+        })
+        .await
+        .unwrap_or(false)
     }
 }
 
-fn verify_argon2id(password_hash: &str, candidate: &[u8]) -> bool {
-    let Ok(parsed_hash) = PasswordHash::new(password_hash) else {
-        return false;
-    };
+fn shared_argon2_verifier() -> Arc<BoundedArgon2Verifier> {
+    static VERIFIER: OnceLock<Arc<BoundedArgon2Verifier>> = OnceLock::new();
+    Arc::clone(VERIFIER.get_or_init(|| {
+        let cpu_limit = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+        Arc::new(BoundedArgon2Verifier::new(
+            cpu_limit.min(MAX_CONCURRENT_ARGON2_JOBS),
+            verify_argon2id,
+        ))
+    }))
+}
 
-    if parsed_hash.algorithm.as_str() != "argon2id" {
-        return false;
+fn verify_argon2id(password_hash: &str, candidate: &[u8]) -> bool {
+    if let Some(result) = verify_valid_argon2id(password_hash, candidate) {
+        return result;
     }
 
-    Argon2::default()
-        .verify_password(candidate, &parsed_hash)
-        .is_ok()
+    // Invalid configured hashes still consume work comparable to an unknown username.
+    let _ = verify_valid_argon2id(DUMMY_ARGON2ID_HASH, candidate);
+    false
+}
+
+fn verify_valid_argon2id(password_hash: &str, candidate: &[u8]) -> Option<bool> {
+    let parsed_hash = PasswordHash::new(password_hash).ok()?;
+    if parsed_hash.algorithm.as_str() != "argon2id" {
+        return None;
+    }
+
+    Some(
+        Argon2::default()
+            .verify_password(candidate, &parsed_hash)
+            .is_ok(),
+    )
+}
+
+fn password_digest(password: &[u8]) -> [u8; 32] {
+    Sha256::digest(password).into()
+}
+
+struct PreparedUser {
+    username: String,
+    credential: PreparedCredential,
+    roles: Option<Vec<String>>,
+}
+
+enum PreparedCredential {
+    Argon2id(String),
+    PlaintextDigest([u8; 32]),
+}
+
+impl From<&PlainUserEntry> for PreparedUser {
+    fn from(entry: &PlainUserEntry) -> Self {
+        let credential = match &entry.credential {
+            PlainCredential::Argon2id(credential) => {
+                PreparedCredential::Argon2id(credential.password_hash.clone())
+            }
+            PlainCredential::Plaintext(credential) => {
+                PreparedCredential::PlaintextDigest(password_digest(credential.password.as_bytes()))
+            }
+        };
+
+        Self {
+            username: entry.username.clone(),
+            credential,
+            roles: entry.roles.clone(),
+        }
+    }
 }
 
 /// A `PlainAuthProvider` that implements Basic authentication by
 /// comparing credentials to the user list in `PlainAuthConfig`.
 pub struct PlainAuthProvider {
     pub config: PlainAuthConfig,
+    users: Vec<PreparedUser>,
+    argon2_verifier: Arc<BoundedArgon2Verifier>,
+    dummy_plaintext_digest: [u8; 32],
 }
 
 impl PlainAuthProvider {
     /// Create a new `PlainAuthProvider` from the config struct.
     pub fn new(config: &PlainAuthConfig) -> Self {
+        Self::with_argon2_verifier(config, shared_argon2_verifier())
+    }
+
+    fn with_argon2_verifier(
+        config: &PlainAuthConfig,
+        argon2_verifier: Arc<BoundedArgon2Verifier>,
+    ) -> Self {
         if config
             .users
             .iter()
@@ -163,6 +257,9 @@ impl PlainAuthProvider {
 
         Self {
             config: config.clone(),
+            users: config.users.iter().map(PreparedUser::from).collect(),
+            argon2_verifier,
+            dummy_plaintext_digest: password_digest(DUMMY_PLAINTEXT),
         }
     }
 }
@@ -233,17 +330,44 @@ impl Provider for PlainAuthProvider {
             username = user_part,
             "basic authentication attempt"
         );
-        for entry in &self.config.users {
-            if entry.username == user_part && entry.credential.verify(pass_part).await {
-                return Ok(User::new(
-                    self.config.realm.clone(),
-                    user_part.to_string(),
-                    entry.roles.clone(),
-                    None,
-                    None,
-                    Some(1),
-                ));
+        let candidate_digest = password_digest(pass_part.as_bytes());
+        let Some(entry) = self.users.iter().find(|entry| entry.username == user_part) else {
+            let _ = self
+                .argon2_verifier
+                .verify(DUMMY_ARGON2ID_HASH, pass_part.as_bytes())
+                .await;
+            std::hint::black_box(
+                self.dummy_plaintext_digest
+                    .ct_eq(&candidate_digest)
+                    .unwrap_u8(),
+            );
+            return Err("Wrong username or password".to_string());
+        };
+
+        let password_matches = match &entry.credential {
+            PreparedCredential::Argon2id(password_hash) => {
+                self.argon2_verifier
+                    .verify(password_hash, pass_part.as_bytes())
+                    .await
             }
+            PreparedCredential::PlaintextDigest(expected_digest) => {
+                let _ = self
+                    .argon2_verifier
+                    .verify(DUMMY_ARGON2ID_HASH, pass_part.as_bytes())
+                    .await;
+                expected_digest.ct_eq(&candidate_digest).into()
+            }
+        };
+
+        if password_matches {
+            return Ok(User::new(
+                self.config.realm.clone(),
+                user_part.to_string(),
+                entry.roles.clone(),
+                None,
+                None,
+                Some(1),
+            ));
         }
 
         Err("Wrong username or password".to_string())
@@ -255,6 +379,55 @@ mod tests {
     use super::*;
     use argon2::{Algorithm, Params, PasswordHasher, Version, password_hash::SaltString};
     use base64::engine::general_purpose;
+    use std::{
+        sync::{
+            Mutex,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        task::Poll,
+    };
+
+    struct BlockingVerifierHarness {
+        verifier: Arc<BoundedArgon2Verifier>,
+        started: tokio::sync::mpsc::UnboundedReceiver<()>,
+        release: mpsc::Sender<()>,
+        active: Arc<AtomicUsize>,
+        maximum_active: Arc<AtomicUsize>,
+    }
+
+    fn blocking_verifier_harness(concurrency: usize) -> BlockingVerifierHarness {
+        let (started_tx, started) = tokio::sync::mpsc::unbounded_channel();
+        let (release, release_rx) = mpsc::channel();
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum_active = Arc::new(AtomicUsize::new(0));
+        let closure_active = Arc::clone(&active);
+        let closure_maximum = Arc::clone(&maximum_active);
+
+        let verifier = Arc::new(BoundedArgon2Verifier::new(concurrency, move |_, _| {
+            let active_now = closure_active.fetch_add(1, Ordering::SeqCst) + 1;
+            closure_maximum.fetch_max(active_now, Ordering::SeqCst);
+            started_tx
+                .send(())
+                .expect("test receiver should remain open");
+            release_rx
+                .lock()
+                .expect("release mutex should not be poisoned")
+                .recv()
+                .expect("test should release each verification");
+            closure_active.fetch_sub(1, Ordering::SeqCst);
+            true
+        }));
+
+        BlockingVerifierHarness {
+            verifier,
+            started,
+            release,
+            active,
+            maximum_active,
+        }
+    }
 
     fn plaintext(password: &str) -> PlainCredential {
         PlainCredential::Plaintext(PlaintextCredential {
@@ -750,5 +923,213 @@ mod tests {
         let result = serde_json::from_str::<PlainUserEntry>(r#"{"username":"missing"}"#);
 
         assert!(result.is_err());
+    }
+    #[tokio::test]
+    async fn test_unknown_username_runs_one_dummy_argon2_verification() {
+        let observed_hashes = Arc::new(Mutex::new(Vec::new()));
+        let closure_hashes = Arc::clone(&observed_hashes);
+        let verifier = Arc::new(BoundedArgon2Verifier::new(1, move |password_hash, _| {
+            closure_hashes
+                .lock()
+                .expect("hash mutex should not be poisoned")
+                .push(password_hash.to_owned());
+            false
+        }));
+        let provider = PlainAuthProvider::with_argon2_verifier(&create_test_config(), verifier);
+        let credentials = general_purpose::STANDARD.encode("not-configured:attempt");
+
+        let result = provider.authenticate(&credentials).await;
+
+        assert_eq!(result.unwrap_err(), "Wrong username or password");
+        assert_eq!(
+            observed_hashes
+                .lock()
+                .expect("hash mutex should not be poisoned")
+                .as_slice(),
+            [DUMMY_ARGON2ID_HASH]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_plaintext_compatibility_runs_dummy_argon2_verification() {
+        let observed_hashes = Arc::new(Mutex::new(Vec::new()));
+        let closure_hashes = Arc::clone(&observed_hashes);
+        let verifier = Arc::new(BoundedArgon2Verifier::new(1, move |password_hash, _| {
+            closure_hashes
+                .lock()
+                .expect("hash mutex should not be poisoned")
+                .push(password_hash.to_owned());
+            false
+        }));
+        let provider = PlainAuthProvider::with_argon2_verifier(&create_test_config(), verifier);
+        let credentials = general_purpose::STANDARD.encode("user1:password1");
+
+        let result = provider.authenticate(&credentials).await;
+
+        assert!(result.is_ok());
+        assert_eq!(
+            observed_hashes
+                .lock()
+                .expect("hash mutex should not be poisoned")
+                .as_slice(),
+            [DUMMY_ARGON2ID_HASH]
+        );
+    }
+
+    #[test]
+    fn test_plaintext_comparison_uses_fixed_size_digests() {
+        let expected = password_digest("short".as_bytes());
+        let matching = password_digest("short".as_bytes());
+        let different_length = password_digest("a much longer password".as_bytes());
+
+        assert_eq!(expected.len(), 32);
+        assert!(bool::from(expected.ct_eq(&matching)));
+        assert!(!bool::from(expected.ct_eq(&different_length)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_argon2_concurrency_is_bounded_without_timing_assumptions() {
+        let mut harness = blocking_verifier_harness(2);
+        let provider = Arc::new(PlainAuthProvider::with_argon2_verifier(
+            &PlainAuthConfig {
+                name: "Bounded".to_string(),
+                realm: "test".to_string(),
+                users: vec![PlainUserEntry {
+                    username: "user".to_string(),
+                    credential: PlainCredential::Argon2id(Argon2idCredential {
+                        password_hash: DUMMY_ARGON2ID_HASH.to_string(),
+                    }),
+                    roles: None,
+                }],
+            },
+            Arc::clone(&harness.verifier),
+        ));
+        let credentials = general_purpose::STANDARD.encode("user:password");
+        let tasks: Vec<_> = (0..3)
+            .map(|_| {
+                let provider = Arc::clone(&provider);
+                let credentials = credentials.clone();
+                tokio::spawn(async move { provider.authenticate(&credentials).await })
+            })
+            .collect();
+
+        harness
+            .started
+            .recv()
+            .await
+            .expect("first verification should start");
+        harness
+            .started
+            .recv()
+            .await
+            .expect("second verification should start");
+        assert_eq!(harness.active.load(Ordering::SeqCst), 2);
+        assert_eq!(harness.maximum_active.load(Ordering::SeqCst), 2);
+        assert_eq!(harness.verifier.permits.available_permits(), 0);
+
+        harness
+            .release
+            .send(())
+            .expect("first verification should be releasable");
+        harness
+            .started
+            .recv()
+            .await
+            .expect("third verification should start after a permit is released");
+        assert_eq!(harness.maximum_active.load(Ordering::SeqCst), 2);
+
+        harness
+            .release
+            .send(())
+            .expect("second verification should be releasable");
+        harness
+            .release
+            .send(())
+            .expect("third verification should be releasable");
+        for task in tasks {
+            assert!(
+                task.await
+                    .expect("authentication task should not panic")
+                    .is_ok()
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_cancelled_request_keeps_permit_until_blocking_work_finishes() {
+        let mut harness = blocking_verifier_harness(1);
+        let first_verifier = Arc::clone(&harness.verifier);
+        let first = tokio::spawn(async move {
+            first_verifier
+                .verify(DUMMY_ARGON2ID_HASH, b"first-attempt")
+                .await
+        });
+        harness
+            .started
+            .recv()
+            .await
+            .expect("first verification should start");
+
+        first.abort();
+        assert!(
+            first
+                .await
+                .expect_err("task should be cancelled")
+                .is_cancelled()
+        );
+
+        let second_verifier = Arc::clone(&harness.verifier);
+        let mut second = Box::pin(async move {
+            second_verifier
+                .verify(DUMMY_ARGON2ID_HASH, b"second-attempt")
+                .await
+        });
+        assert!(matches!(futures::poll!(&mut second), Poll::Pending));
+        assert_eq!(harness.verifier.permits.available_permits(), 0);
+        assert_eq!(harness.active.load(Ordering::SeqCst), 1);
+
+        harness
+            .release
+            .send(())
+            .expect("cancelled verification should be releasable");
+        let second = tokio::spawn(second);
+        harness
+            .started
+            .recv()
+            .await
+            .expect("second verification should start after blocking work ends");
+        harness
+            .release
+            .send(())
+            .expect("second verification should be releasable");
+        assert!(second.await.expect("second task should not panic"));
+        assert_eq!(harness.maximum_active.load(Ordering::SeqCst), 1);
+    }
+    #[test]
+    fn test_config_debug_output_redacts_credentials() {
+        let config = PlainAuthConfig {
+            name: "Redacted".to_string(),
+            realm: "test".to_string(),
+            users: vec![
+                PlainUserEntry {
+                    username: "legacy".to_string(),
+                    credential: plaintext("plaintext-must-not-appear"),
+                    roles: None,
+                },
+                PlainUserEntry {
+                    username: "hashed".to_string(),
+                    credential: PlainCredential::Argon2id(Argon2idCredential {
+                        password_hash: "hash-must-not-appear".to_string(),
+                    }),
+                    roles: None,
+                },
+            ],
+        };
+
+        let output = format!("{config:?}");
+
+        assert!(!output.contains("plaintext-must-not-appear"));
+        assert!(!output.contains("hash-must-not-appear"));
+        assert_eq!(output.matches("[REDACTED]").count(), 2);
     }
 }

--- a/authotron/tests/offline_integration.rs
+++ b/authotron/tests/offline_integration.rs
@@ -27,11 +27,11 @@ providers:
     realm: "ecmwf"
     users:
         - username: adam
-          password: admin
+          password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wOA$F6E6TTxfuya9egnIBJBZ1vIOBLiPqDQcYQK1dSjnFW4"
           roles:
             - user
         - username: eve
-          password: admin
+          password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wOA$F6E6TTxfuya9egnIBJBZ1vIOBLiPqDQcYQK1dSjnFW4"
           roles:
             - superuser
   - name: "Plain provider"
@@ -39,7 +39,7 @@ providers:
     realm: "other"
     users:
         - username: adam
-          password: other
+          password_hash: "$argon2id$v=19$m=19456,t=2,p=1$YXV0aG90cm9uLWRvYy0wOQ$b5CrRmzNWov2aZK7XxcX9XLc4ce0vja7GJRHm62dWXI"
           roles:
             - user
 


### PR DESCRIPTION
## Changes
- add Argon2id PHC password verification and exact-one `password_hash`/`password` configuration
- globally bound Argon2 work to `min(available CPUs, 2)`, with permits held by blocking closures through cancellation
- run a default-cost dummy verification for unknown usernames and plaintext compatibility entries
- compare precomputed fixed-size plaintext digests in constant time and redact credentials from debug output
- update schema, examples, tests, and provider documentation

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo build --release -p authotron`
- `mdbook build authotron/docs`

## Deprecation
Plaintext `password` entries remain migration-only compatibility and emit one warning per provider. Use Argon2id `password_hash` entries with consistent PHC cost parameters.

<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/authotron/pull-requests/PR-85
<!-- PREVIEW-PUBLISH-AUTH-O-TRON-DOCS_END -->